### PR TITLE
Ignore numeric only strings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    ecmaFeatures: {
+      jsx: true,
+    },
+  },
+  env: {
+    node: true,
+    es2020: true,
+  },
+  extends: [
+    'eslint:recommended',
+  ],
+  rules: {
+    // Add any specific rules here if needed
+    'no-unused-vars': 'off', // TypeScript handles this
+    'no-undef': 'off', // TypeScript handles this
+  },
+  ignorePatterns: [
+    'lib/**',
+    'node_modules/**',
+    'tests/**',
+  ],
+};

--- a/docs/rules/no-hardcoded-jsx-attributes.md
+++ b/docs/rules/no-hardcoded-jsx-attributes.md
@@ -8,7 +8,7 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 ## What it checks
 - Attributes: `aria-label`, `aria-description`, `aria-valuetext`, `aria-roledescription`, `title`, `alt`, `placeholder`, and other `aria-*` (excludes idrefs).
 - Static values: `attr="Hello"`, `attr={'Hello'}`, `attr={` + "`Hello`" + `}`.
-- Ignores: `aria-labelledby`, `aria-describedby` (ID refs), and tags `title`, `style`, `script`. Punctuation/emoji-only strings are ignored.
+- Ignores: `aria-labelledby`, `aria-describedby` (ID refs), tags `title`, `style`, `script`, punctuation/emoji-only strings, and numeric-only strings.
 
 ## Examples
 ### Invalid
@@ -23,6 +23,8 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 <button aria-label={t('actions.save')} />
 <div aria-labelledby="heading-id" />
 <div title="— —" />              // punctuation only
+<div aria-label="123" />         // numeric only
+<img alt={'999'} />              // numeric only
 <script title="Hello" />          // ignored tag
 ```
 
@@ -35,3 +37,5 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
   }
 }
 ```
+
+**Note:** Numeric-only strings (e.g., `"1"`, `"123"`, `"999"`) are automatically ignored as they typically don't require internationalization.

--- a/docs/rules/no-hardcoded-jsx-text.md
+++ b/docs/rules/no-hardcoded-jsx-text.md
@@ -8,7 +8,7 @@ Hardcoded strings block localization and consistency. This rule helps surface th
 ## What it checks
 - JSX text nodes: `<div>Hello</div>`
 - Static strings in expression containers: `<div>{'Hello'}</div>`, `<div>{` + "`Hello`" + `}</div>`
-- Ignores: whitespace-only, non-alphanumeric-only (punctuation/emoji), and content inside `title`, `style`, `script` tags.
+- Ignores: whitespace-only, non-alphanumeric-only (punctuation/emoji), numeric-only strings, and content inside `title`, `style`, `script` tags.
 
 ## Examples
 ### Invalid
@@ -24,6 +24,8 @@ const C = () => <div>{t('home.title')}</div>;
 const C = () => <Trans>Clicks: {count}</Trans>;
 const C = () => <div>{' '}</div>;       // whitespace only
 const C = () => <div>🙂🙂</div>;          // emoji only
+const C = () => <div>123</div>;         // numeric only
+const C = () => <span>{'999'}</span>;   // numeric only
 const C = () => <style>{'.foo{color:red}'}</style>; // ignored tag
 ```
 
@@ -58,6 +60,8 @@ const C = () => <style>{'.foo{color:red}'}</style>; // ignored tag
 - `ignoreLiterals` (string[], default: `["404", "N/A"]`) - Array of string literals to ignore. These strings will not trigger the rule when found in JSX text.
 - `caseSensitive` (boolean, default: `false`) - Whether to use case-sensitive matching when comparing against `ignoreLiterals`.
 - `trim` (boolean, default: `true`) - Whether to trim whitespace from strings before comparing against `ignoreLiterals`.
+
+**Note:** Numeric-only strings (e.g., `"1"`, `"123"`, `"999"`) are automatically ignored regardless of configuration options.
 
 ### Examples with ignore list
 

--- a/lib/no-hardcoded-jsx-attributes.js
+++ b/lib/no-hardcoded-jsx-attributes.js
@@ -60,6 +60,9 @@ exports.default = createRule({
                         return;
                     if (!/[a-zA-Z0-9]/.test(text))
                         return;
+                    // Ignore numeric-only strings
+                    if (/^[0-9]+$/.test(text))
+                        return;
                     context.report({ node: value, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
                     return;
                 }
@@ -72,6 +75,9 @@ exports.default = createRule({
                             return;
                         if (!/[a-zA-Z0-9]/.test(text))
                             return;
+                        // Ignore numeric-only strings
+                        if (/^[0-9]+$/.test(text))
+                            return;
                         context.report({ node: expr, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
                         return;
                     }
@@ -81,6 +87,9 @@ exports.default = createRule({
                         if (!text)
                             return;
                         if (!/[a-zA-Z0-9]/.test(text))
+                            return;
+                        // Ignore numeric-only strings
+                        if (/^[0-9]+$/.test(text))
                             return;
                         context.report({ node: expr, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
                         return;

--- a/lib/no-hardcoded-jsx-text.js
+++ b/lib/no-hardcoded-jsx-text.js
@@ -77,6 +77,9 @@ exports.default = createRule({
                     if (ignoredTags.includes(tagName))
                         return;
                 }
+                // Ignore numeric-only strings
+                if (/^[0-9]+$/.test(value))
+                    return;
                 // Check if the string should be ignored based on configuration
                 if (shouldIgnoreString(raw))
                     return;
@@ -103,6 +106,9 @@ exports.default = createRule({
                         return;
                     if (!/[a-zA-Z0-9]/.test(text))
                         return;
+                    // Ignore numeric-only strings
+                    if (/^[0-9]+$/.test(text))
+                        return;
                     if (shouldIgnoreString(expr.value))
                         return;
                     context.report({ node: expr, messageId: 'noHardcoded', data: { text } });
@@ -115,6 +121,9 @@ exports.default = createRule({
                     if (!text)
                         return;
                     if (!/[a-zA-Z0-9]/.test(text))
+                        return;
+                    // Ignore numeric-only strings
+                    if (/^[0-9]+$/.test(text))
                         return;
                     if (shouldIgnoreString(cooked))
                         return;

--- a/src/no-hardcoded-jsx-attributes.ts
+++ b/src/no-hardcoded-jsx-attributes.ts
@@ -67,6 +67,8 @@ export default createRule<Options, MessageIds>({
           const text = value.value.trim();
           if (!text) return;
           if (!/[a-zA-Z0-9]/.test(text)) return;
+          // Ignore numeric-only strings
+          if (/^[0-9]+$/.test(text)) return;
           context.report({ node: value, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
           return;
         }
@@ -78,6 +80,8 @@ export default createRule<Options, MessageIds>({
             const text = expr.value.trim();
             if (!text) return;
             if (!/[a-zA-Z0-9]/.test(text)) return;
+            // Ignore numeric-only strings
+            if (/^[0-9]+$/.test(text)) return;
             context.report({ node: expr, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
             return;
           }
@@ -86,6 +90,8 @@ export default createRule<Options, MessageIds>({
             const text = cooked.trim();
             if (!text) return;
             if (!/[a-zA-Z0-9]/.test(text)) return;
+            // Ignore numeric-only strings
+            if (/^[0-9]+$/.test(text)) return;
             context.report({ node: expr, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
             return;
           }

--- a/src/no-hardcoded-jsx-text.ts
+++ b/src/no-hardcoded-jsx-text.ts
@@ -96,6 +96,9 @@ export default createRule<Options, MessageIds>({
           if (ignoredTags.includes(tagName)) return;
         }
 
+        // Ignore numeric-only strings
+        if (/^[0-9]+$/.test(value)) return;
+
         // Check if the string should be ignored based on configuration
         if (shouldIgnoreString(raw)) return;
 
@@ -122,6 +125,8 @@ export default createRule<Options, MessageIds>({
           const text = expr.value.trim();
           if (!text) return;
           if (!/[a-zA-Z0-9]/.test(text)) return;
+          // Ignore numeric-only strings
+          if (/^[0-9]+$/.test(text)) return;
           if (shouldIgnoreString(expr.value)) return;
           context.report({ node: expr, messageId: 'noHardcoded', data: { text } });
           return;
@@ -133,6 +138,8 @@ export default createRule<Options, MessageIds>({
           const text = cooked.trim();
           if (!text) return;
           if (!/[a-zA-Z0-9]/.test(text)) return;
+          // Ignore numeric-only strings
+          if (/^[0-9]+$/.test(text)) return;
           if (shouldIgnoreString(cooked)) return;
           context.report({ node: expr, messageId: 'noHardcoded', data: { text } });
           return;

--- a/tests/no-hardcoded-jsx-attributes.test.js
+++ b/tests/no-hardcoded-jsx-attributes.test.js
@@ -27,6 +27,11 @@ ruleTester.run('no-hardcoded-jsx-attributes', rule, {
     // punctuation / emoji only
     { code: 'const C = () => <div title="— —" />;' },
     { code: 'const C = () => <div alt={"🙂"} />;' },
+    // numeric only -> ignored
+    { code: 'const C = () => <div aria-label="123" />;' },
+    { code: 'const C = () => <img alt={"999"} />;' },
+    { code: 'const C = () => <input placeholder={`42`} />;' },
+    { code: 'const C = () => <div title="1" />;' },
     // ignored tags
     { code: 'const C = () => <script title="Hello" />;' },
   ],

--- a/tests/no-hardcoded-jsx-text.test.js
+++ b/tests/no-hardcoded-jsx-text.test.js
@@ -25,6 +25,10 @@ ruleTester.run('no-hardcoded-jsx-text', rule, {
     { code: 'const C = () => <div>— … • ✓</div>;' },
     // Emoji only -> ignored
     { code: 'const C = () => <div>🙂🙂</div>;' },
+    // Numeric only -> ignored
+    { code: 'const C = () => <div>123</div>;' },
+    { code: 'const C = () => <div>1</div>;' },
+    { code: 'const C = () => <div>999</div>;' },
     // Attribute text is not JSXText -> not reported by this rule
     { code: 'const C = () => <div aria-label="Hello" />;' },
     // Script tag content ignored by rule
@@ -34,6 +38,9 @@ ruleTester.run('no-hardcoded-jsx-text', rule, {
     { code: 'const C = () => <div>{`Hello ${name}`}</div>;' },
     { code: 'const C = () => <title>{"Home"}</title>;' },
     { code: 'const C = () => <div>{"🙂"}</div>;' },
+    // Numeric only in expression containers -> ignored
+    { code: 'const C = () => <div>{"123"}</div>;' },
+    { code: 'const C = () => <div>{`999`}</div>;' },
   ],
   invalid: [
     {
@@ -42,10 +49,6 @@ ruleTester.run('no-hardcoded-jsx-text', rule, {
     },
     {
       code: 'const C = () => <div>  Hello world!  </div>;',
-      errors: [{ messageId: 'noHardcoded' }],
-    },
-    {
-      code: 'const C = () => <div>123</div>;',
       errors: [{ messageId: 'noHardcoded' }],
     },
     {
@@ -63,10 +66,6 @@ ruleTester.run('no-hardcoded-jsx-text', rule, {
     },
     {
       code: 'const C = () => <div>{`Hello`}</div>;',
-      errors: [{ messageId: 'noHardcoded' }],
-    },
-    {
-      code: 'const C = () => <div>{"123"}</div>;',
       errors: [{ messageId: 'noHardcoded' }],
     },
     {


### PR DESCRIPTION
## Summary
Add automatic ignoring of numeric-only strings in both no-hardcoded-jsx-text and no-hardcoded-jsx-attributes rules. This prevents false positives for numeric content that typically doesn't require internationalization.

## Changes
 - JSX Text Rule: Ignore strings like "123", "1", "999" in JSX text nodes and expression containers
 - JSX Attributes Rule: Ignore numeric-only values in user-visible attributes like aria-label="123", alt="999"
 - Both rules now use `/^[0-9]+$/ regex to detect pure numeric strings
 - Mixed content like "404 Not Found" or "123abc" still triggers the rules as expected