### PR TITLE
Feat: add ignore list functionality to no-hardcoded-jsx-attributes rule

### DIFF
--- a/docs/rules/no-hardcoded-jsx-attributes.md
+++ b/docs/rules/no-hardcoded-jsx-attributes.md
@@ -25,10 +25,14 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 <div title="— —" />              // punctuation only
 <div aria-label="123" />         // numeric only
 <img alt={'999'} />              // numeric only
+<div title="404" />              // ignored by default
+<span aria-label="N/A" />       // ignored by default
 <script title="Hello" />          // ignored tag
 ```
 
 ## Configuration
+
+### Basic usage
 ```json
 {
   "plugins": ["i18n-rules"],
@@ -38,4 +42,39 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 }
 ```
 
-**Note:** Numeric-only strings (e.g., `"1"`, `"123"`, `"999"`) are automatically ignored as they typically don't require internationalization.
+### With options
+```json
+{
+  "plugins": ["i18n-rules"],
+  "rules": {
+    "i18n-rules/no-hardcoded-jsx-attributes": ["error", {
+      "ignoreLiterals": ["404", "N/A", "SKU-0001"],
+      "caseSensitive": false,
+      "trim": true
+    }]
+  }
+}
+```
+
+### Options
+
+- `ignoreLiterals` (string[], default: `["404", "N/A"]`) - Array of string literals to ignore. These strings will not trigger the rule when found in JSX attributes.
+- `caseSensitive` (boolean, default: `false`) - Whether to use case-sensitive matching when comparing against `ignoreLiterals`.
+- `trim` (boolean, default: `true`) - Whether to trim whitespace from strings before comparing against `ignoreLiterals`.
+
+**Note:** Numeric-only strings (e.g., `"1"`, `"123"`, `"999"`) are automatically ignored regardless of configuration options.
+
+### Examples with ignore list
+
+#### Valid (with default options)
+```tsx
+const ErrorPage = () => <div aria-label="404" />;     // ignored by default
+const UserProfile = () => <img alt="N/A" />;         // ignored by default
+```
+
+#### Valid (with custom ignore list)
+```tsx
+// With configuration: { "ignoreLiterals": ["SKU-123", "v1.0"] }
+const Product = () => <div title="SKU-123" />;       // ignored
+const Version = () => <span aria-label="v1.0" />;   // ignored
+```

--- a/lib/no-hardcoded-jsx-attributes.js
+++ b/lib/no-hardcoded-jsx-attributes.js
@@ -26,10 +26,51 @@ exports.default = createRule({
         messages: {
             noHardcodedAttr: "Avoid hardcoded string '{{ text }}' in JSX attribute '{{ attr }}' — use t().",
         },
-        schema: [],
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    ignoreLiterals: {
+                        type: 'array',
+                        items: { type: 'string' },
+                        default: ['404', 'N/A']
+                    },
+                    caseSensitive: {
+                        type: 'boolean',
+                        default: false
+                    },
+                    trim: {
+                        type: 'boolean',
+                        default: true
+                    }
+                },
+                additionalProperties: false
+            }
+        ],
     },
-    defaultOptions: [],
+    defaultOptions: [{
+            ignoreLiterals: ['404', 'N/A'],
+            caseSensitive: false,
+            trim: true
+        }],
     create(context) {
+        const options = context.options[0] || {};
+        const { ignoreLiterals = ['404', 'N/A'], caseSensitive = false, trim: shouldTrim = true } = options;
+        const shouldIgnoreString = (text) => {
+            let normalizedText = text;
+            if (shouldTrim) {
+                normalizedText = normalizedText.trim();
+            }
+            return ignoreLiterals.some(ignored => {
+                let normalizedIgnored = ignored;
+                let textToCompare = normalizedText;
+                if (!caseSensitive) {
+                    normalizedIgnored = normalizedIgnored.toLowerCase();
+                    textToCompare = textToCompare.toLowerCase();
+                }
+                return textToCompare === normalizedIgnored;
+            });
+        };
         return {
             JSXAttribute(node) {
                 // Resolve attribute name
@@ -63,6 +104,9 @@ exports.default = createRule({
                     // Ignore numeric-only strings
                     if (/^[0-9]+$/.test(text))
                         return;
+                    // Check if the string should be ignored based on configuration
+                    if (shouldIgnoreString(value.value))
+                        return;
                     context.report({ node: value, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
                     return;
                 }
@@ -78,6 +122,9 @@ exports.default = createRule({
                         // Ignore numeric-only strings
                         if (/^[0-9]+$/.test(text))
                             return;
+                        // Check if the string should be ignored based on configuration
+                        if (shouldIgnoreString(expr.value))
+                            return;
                         context.report({ node: expr, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
                         return;
                     }
@@ -90,6 +137,9 @@ exports.default = createRule({
                             return;
                         // Ignore numeric-only strings
                         if (/^[0-9]+$/.test(text))
+                            return;
+                        // Check if the string should be ignored based on configuration
+                        if (shouldIgnoreString(cooked))
                             return;
                         context.report({ node: expr, messageId: 'noHardcodedAttr', data: { text, attr: attrName } });
                         return;

--- a/tests/no-hardcoded-jsx-attributes.test.js
+++ b/tests/no-hardcoded-jsx-attributes.test.js
@@ -34,6 +34,11 @@ ruleTester.run('no-hardcoded-jsx-attributes', rule, {
     { code: 'const C = () => <div title="1" />;' },
     // ignored tags
     { code: 'const C = () => <script title="Hello" />;' },
+    // default ignore list
+    { code: 'const C = () => <div aria-label="404" />;' },
+    { code: 'const C = () => <img alt="N/A" />;' },
+    { code: 'const C = () => <div title={"404"} />;' },
+    { code: 'const C = () => <span aria-label={`N/A`} />;' },
   ],
   invalid: [
     { code: 'const C = () => <button type="button" aria-label="Save" />;', errors: [{ messageId: 'noHardcodedAttr' }] },
@@ -43,6 +48,61 @@ ruleTester.run('no-hardcoded-jsx-attributes', rule, {
     { code: 'const C = () => <div title={`Hello`} />;', errors: [{ messageId: 'noHardcodedAttr' }] },
     { code: 'const C = () => <div aria-description="Helpful text" />;', errors: [{ messageId: 'noHardcodedAttr' }] },
     { code: 'const C = () => <div aria-roledescription={"Button-like"} />;', errors: [{ messageId: 'noHardcodedAttr' }] },
+  ],
+});
+
+// Test with custom ignore list
+ruleTester.run('no-hardcoded-jsx-attributes with custom ignore list', rule, {
+  valid: [
+    { 
+      code: 'const C = () => <div aria-label="SKU-123" />;',
+      options: [{ ignoreLiterals: ['SKU-123', 'v1.0'] }]
+    },
+    { 
+      code: 'const C = () => <img alt={"v1.0"} />;',
+      options: [{ ignoreLiterals: ['SKU-123', 'v1.0'] }]
+    },
+  ],
+  invalid: [
+    { 
+      code: 'const C = () => <div aria-label="Hello" />;',
+      options: [{ ignoreLiterals: ['SKU-123', 'v1.0'] }],
+      errors: [{ messageId: 'noHardcodedAttr' }]
+    },
+  ],
+});
+
+// Test case sensitivity
+ruleTester.run('no-hardcoded-jsx-attributes case sensitivity', rule, {
+  valid: [
+    { 
+      code: 'const C = () => <div aria-label="hello" />;',
+      options: [{ ignoreLiterals: ['HELLO'], caseSensitive: false }]
+    },
+  ],
+  invalid: [
+    { 
+      code: 'const C = () => <div aria-label="hello" />;',
+      options: [{ ignoreLiterals: ['HELLO'], caseSensitive: true }],
+      errors: [{ messageId: 'noHardcodedAttr' }]
+    },
+  ],
+});
+
+// Test trim option
+ruleTester.run('no-hardcoded-jsx-attributes trim option', rule, {
+  valid: [
+    { 
+      code: 'const C = () => <div aria-label="  hello  " />;',
+      options: [{ ignoreLiterals: ['hello'], trim: true }]
+    },
+  ],
+  invalid: [
+    { 
+      code: 'const C = () => <div aria-label="  hello  " />;',
+      options: [{ ignoreLiterals: ['hello'], trim: false }],
+      errors: [{ messageId: 'noHardcodedAttr' }]
+    },
   ],
 });
 


### PR DESCRIPTION
## Summary
Add configurable ignore list support to JSX attributes rule, matching the functionality of the JSX text rule. Users can now specify strings to ignore via rule options.

## Features:
- ignoreLiterals: Array of strings to ignore (default: ['404', 'N/A'])
- caseSensitive: Case-sensitive matching (default: false)
- trim: Trim whitespace before comparison (default: true)

## Changes:
- Add rule options schema and default configuration
- Add shouldIgnoreString helper function with normalization logic
- Integrate ignore checks in all three string value handlers
