### PR TITLE
Enhance `no-hardcoded-jsx-attributes` rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Add to your ESLint config:
   "plugins": ["i18n-rules"],
   "rules": {
     "i18n-rules/no-hardcoded-jsx-text": "error",
-    "i18n-rules/no-hardcoded-jsx-attributes": "error"
+    "i18n-rules/no-hardcoded-jsx-attributes": "warn"
   }
 }
 ```

--- a/docs/rules/no-hardcoded-jsx-attributes.md
+++ b/docs/rules/no-hardcoded-jsx-attributes.md
@@ -37,7 +37,7 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 {
   "plugins": ["i18n-rules"],
   "rules": {
-    "i18n-rules/no-hardcoded-jsx-attributes": "error"
+    "i18n-rules/no-hardcoded-jsx-attributes": "warn"
   }
 }
 ```
@@ -47,7 +47,7 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 {
   "plugins": ["i18n-rules"],
   "rules": {
-    "i18n-rules/no-hardcoded-jsx-attributes": ["error", {
+    "i18n-rules/no-hardcoded-jsx-attributes": ["warn", {
       "ignoreLiterals": ["404", "N/A", "SKU-0001"],
       "caseSensitive": false,
       "trim": true

--- a/lib/index.js
+++ b/lib/index.js
@@ -9,4 +9,15 @@ module.exports = {
         'no-hardcoded-jsx-text': no_hardcoded_jsx_text_1.default,
         'no-hardcoded-jsx-attributes': no_hardcoded_jsx_attributes_1.default,
     },
+    configs: {
+        recommended: {
+            rules: {
+                'i18n-rules/no-hardcoded-jsx-attributes': ['warn', {
+                        ignoreLiterals: ['404', 'N/A', 'SKU-0001'],
+                        caseSensitive: false,
+                        trim: true
+                    }]
+            }
+        }
+    }
 };

--- a/lib/no-hardcoded-jsx-attributes.js
+++ b/lib/no-hardcoded-jsx-attributes.js
@@ -14,6 +14,7 @@ const TARGET_ATTRS = new Set([
 const IDREF_ATTRS = new Set([
     'aria-labelledby',
     'aria-describedby',
+    'aria-hidden',
 ]);
 exports.default = createRule({
     name: 'no-hardcoded-jsx-attributes',

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,4 +6,15 @@ export = {
     'no-hardcoded-jsx-text': noHardcodedJsxText,
     'no-hardcoded-jsx-attributes': noHardcodedJsxAttributes,
   },
+  configs: {
+    recommended: {
+      rules: {
+        'i18n-rules/no-hardcoded-jsx-attributes': ['warn', {
+          ignoreLiterals: ['404', 'N/A', 'SKU-0001'],
+          caseSensitive: false,
+          trim: true
+        }]
+      }
+    }
+  }
 };

--- a/src/no-hardcoded-jsx-attributes.ts
+++ b/src/no-hardcoded-jsx-attributes.ts
@@ -25,6 +25,7 @@ const TARGET_ATTRS = new Set([
 const IDREF_ATTRS = new Set([
   'aria-labelledby',
   'aria-describedby',
+  'aria-hidden',
 ]);
 
 export default createRule<Options, MessageIds>({
@@ -73,20 +74,20 @@ export default createRule<Options, MessageIds>({
 
     const shouldIgnoreString = (text: string): boolean => {
       let normalizedText = text;
-      
+
       if (shouldTrim) {
         normalizedText = normalizedText.trim();
       }
-      
+
       return ignoreLiterals.some(ignored => {
         let normalizedIgnored = ignored;
         let textToCompare = normalizedText;
-        
+
         if (!caseSensitive) {
           normalizedIgnored = normalizedIgnored.toLowerCase();
           textToCompare = textToCompare.toLowerCase();
         }
-        
+
         return textToCompare === normalizedIgnored;
       });
     };

--- a/tests/no-hardcoded-jsx-attributes.test.js
+++ b/tests/no-hardcoded-jsx-attributes.test.js
@@ -39,6 +39,8 @@ ruleTester.run('no-hardcoded-jsx-attributes', rule, {
     { code: 'const C = () => <img alt="N/A" />;' },
     { code: 'const C = () => <div title={"404"} />;' },
     { code: 'const C = () => <span aria-label={`N/A`} />;' },
+    { code: 'const C = () => <span aria-hidden="true" />;' },
+    { code: 'const C = () => <span aria-hidden="false" />;' },
   ],
   invalid: [
     { code: 'const C = () => <button type="button" aria-label="Save" />;', errors: [{ messageId: 'noHardcodedAttr' }] },
@@ -54,17 +56,17 @@ ruleTester.run('no-hardcoded-jsx-attributes', rule, {
 // Test with custom ignore list
 ruleTester.run('no-hardcoded-jsx-attributes with custom ignore list', rule, {
   valid: [
-    { 
+    {
       code: 'const C = () => <div aria-label="SKU-123" />;',
       options: [{ ignoreLiterals: ['SKU-123', 'v1.0'] }]
     },
-    { 
+    {
       code: 'const C = () => <img alt={"v1.0"} />;',
       options: [{ ignoreLiterals: ['SKU-123', 'v1.0'] }]
     },
   ],
   invalid: [
-    { 
+    {
       code: 'const C = () => <div aria-label="Hello" />;',
       options: [{ ignoreLiterals: ['SKU-123', 'v1.0'] }],
       errors: [{ messageId: 'noHardcodedAttr' }]
@@ -75,13 +77,13 @@ ruleTester.run('no-hardcoded-jsx-attributes with custom ignore list', rule, {
 // Test case sensitivity
 ruleTester.run('no-hardcoded-jsx-attributes case sensitivity', rule, {
   valid: [
-    { 
+    {
       code: 'const C = () => <div aria-label="hello" />;',
       options: [{ ignoreLiterals: ['HELLO'], caseSensitive: false }]
     },
   ],
   invalid: [
-    { 
+    {
       code: 'const C = () => <div aria-label="hello" />;',
       options: [{ ignoreLiterals: ['HELLO'], caseSensitive: true }],
       errors: [{ messageId: 'noHardcodedAttr' }]
@@ -92,13 +94,13 @@ ruleTester.run('no-hardcoded-jsx-attributes case sensitivity', rule, {
 // Test trim option
 ruleTester.run('no-hardcoded-jsx-attributes trim option', rule, {
   valid: [
-    { 
+    {
       code: 'const C = () => <div aria-label="  hello  " />;',
       options: [{ ignoreLiterals: ['hello'], trim: true }]
     },
   ],
   invalid: [
-    { 
+    {
       code: 'const C = () => <div aria-label="  hello  " />;',
       options: [{ ignoreLiterals: ['hello'], trim: false }],
       errors: [{ messageId: 'noHardcodedAttr' }]


### PR DESCRIPTION
## Summary
 - Change `no-hardcoded-jsx-attributes` rule default severity from error to warning
 - Add recommended config with warning level and standard ignore list
 - Exclude aria-hidden boolean attribute from validation