### PR TITLE
feat: ignore hardcoded strings inside Trans components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,5 +68,5 @@ The `no-hardcoded-jsx-text` rule specifically:
 # Workflow
 
 - Checkout a new branch before do your task
-- Be sure to type check (run `yarn format`, `yarn test`, `yarn build`) when you’re done making a series of code changes
+- Be sure to type check (run `yarn test`, `yarn build`, `yarn format` ) when you’re done making a series of code changes
 - Prefer running single tests, and not the whole test suite, for performance

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Prevents hardcoded strings in JSX text content and expression containers.
 <Trans>Welcome {name}</Trans>             // i18n component
 <div>{" "}</div>                          // Whitespace (ignored)
 <title>Page Title</title>                 // HTML metadata (ignored)
+<Trans i18nKey="welcome">Welcome to our app</Trans>  // Trans content ignored
 ```
 
 ### `no-hardcoded-jsx-attributes` 🆕
@@ -142,6 +143,7 @@ The plugin intelligently filters out content that doesn't need internationalizat
 - **Punctuation/Symbols**: `<div>— • ✓</div>`, `<span>{"..."}</span>`
 - **Emojis**: `<div>🎉🚀</div>`, `<button>{"😊"}</button>`
 - **HTML Metadata**: `<title>`, `<style>`, `<script>` content
+- **Trans Components**: Content inside `<Trans>` components from next-i18next
 - **ID References**: `aria-labelledby`, `aria-describedby` attributes
 
 ### Dynamic Content (Allowed)

--- a/docs/rules/no-hardcoded-jsx-text.md
+++ b/docs/rules/no-hardcoded-jsx-text.md
@@ -10,7 +10,7 @@ Hardcoded strings block localization and consistency. This rule helps surface th
 
 - JSX text nodes: `<div>Hello</div>`
 - Static strings in expression containers: `<div>{'Hello'}</div>`, `<div>{` + "`Hello`" + `}</div>`
-- Ignores: whitespace-only, non-alphanumeric-only (punctuation/emoji), numeric-only strings, and content inside `title`, `style`, `script` tags.
+- Ignores: whitespace-only, non-alphanumeric-only (punctuation/emoji), numeric-only strings, content inside `title`, `style`, `script` tags, and **content inside `<Trans>` components**.
 
 ## Examples
 
@@ -32,6 +32,9 @@ const C = () => <div>🙂🙂</div>; // emoji only
 const C = () => <div>123</div>; // numeric only
 const C = () => <span>{"999"}</span>; // numeric only
 const C = () => <style>{".foo{color:red}"}</style>; // ignored tag
+// Trans component content is ignored
+const C = () => <Trans i18nKey="welcome">Welcome to our app</Trans>;
+const C = () => <Trans>Your request to join <span>company</span> has been approved</Trans>;
 ```
 
 ## Configuration

--- a/lib/no-hardcoded-jsx-text.js
+++ b/lib/no-hardcoded-jsx-text.js
@@ -69,6 +69,20 @@ exports.default = createRule({
         return textToCompare === normalizedIgnored;
       });
     };
+    const isInsideTransComponent = (node) => {
+      let current = node.parent;
+      while (current) {
+        if (
+          current.type === "JSXElement" &&
+          current.openingElement.name.type === "JSXIdentifier" &&
+          current.openingElement.name.name === "Trans"
+        ) {
+          return true;
+        }
+        current = current.parent;
+      }
+      return false;
+    };
     return {
       JSXText(node) {
         const raw = node.value;
@@ -77,6 +91,8 @@ exports.default = createRule({
         if (!value) return;
         // Ignore if string does not contain any alphabet or digit
         if (!/[a-zA-Z0-9]/.test(value)) return;
+        // Skip if inside a Trans component
+        if (isInsideTransComponent(node)) return;
         // Skip specific tags like <title>, <style>, etc.
         const parent = node.parent;
         if (
@@ -99,6 +115,8 @@ exports.default = createRule({
         });
       },
       JSXExpressionContainer(node) {
+        // Skip if inside a Trans component
+        if (isInsideTransComponent(node)) return;
         const parent = node.parent;
         if (
           (parent === null || parent === void 0 ? void 0 : parent.type) ===

--- a/src/no-hardcoded-jsx-text.ts
+++ b/src/no-hardcoded-jsx-text.ts
@@ -84,6 +84,21 @@ export default createRule<Options, MessageIds>({
       });
     };
 
+    const isInsideTransComponent = (node: TSESTree.Node): boolean => {
+      let current = node.parent;
+      while (current) {
+        if (
+          current.type === "JSXElement" &&
+          current.openingElement.name.type === "JSXIdentifier" &&
+          current.openingElement.name.name === "Trans"
+        ) {
+          return true;
+        }
+        current = current.parent;
+      }
+      return false;
+    };
+
     return {
       JSXText(node: TSESTree.JSXText) {
         const raw = node.value;
@@ -94,6 +109,9 @@ export default createRule<Options, MessageIds>({
 
         // Ignore if string does not contain any alphabet or digit
         if (!/[a-zA-Z0-9]/.test(value)) return;
+
+        // Skip if inside a Trans component
+        if (isInsideTransComponent(node)) return;
 
         // Skip specific tags like <title>, <style>, etc.
         const parent = node.parent;
@@ -119,6 +137,9 @@ export default createRule<Options, MessageIds>({
         });
       },
       JSXExpressionContainer(node: TSESTree.JSXExpressionContainer) {
+        // Skip if inside a Trans component
+        if (isInsideTransComponent(node)) return;
+
         const parent = node.parent;
         if (
           parent?.type === "JSXElement" &&

--- a/tests/no-hardcoded-jsx-text.test.js
+++ b/tests/no-hardcoded-jsx-text.test.js
@@ -43,6 +43,18 @@ ruleTester.run("no-hardcoded-jsx-text", rule, {
     // Numeric only in expression containers -> ignored
     { code: 'const C = () => <div>{"123"}</div>;' },
     { code: "const C = () => <div>{`999`}</div>;" },
+    // Trans component content should be ignored
+    {
+      code: 'const C = () => <Trans i18nKey="key">Hardcoded text inside Trans</Trans>;',
+    },
+    {
+      code: "const C = () => <Trans>Your request to join <span>company</span> has been approved</Trans>;",
+    },
+    {
+      code: 'const C = () => <Trans i18nKey="nested"><div>Nested content <span>should be ignored</span></div></Trans>;',
+    },
+    { code: 'const C = () => <Trans>{"Static string in expression"}</Trans>;' },
+    { code: "const C = () => <Trans>{`Template literal content`}</Trans>;" },
   ],
   invalid: [
     {


### PR DESCRIPTION
- Add isInsideTransComponent helper function to check if JSX nodes are inside Trans components
- Skip linting JSXText and JSXExpressionContainer nodes when inside Trans components
- Add comprehensive test cases for Trans component ignore functionality
- Support nested elements and expression containers within Trans components

### Fixed
<img width="1117" height="337" alt="Screenshot 2025-09-10 at 13 09 31" src="https://github.com/user-attachments/assets/40ab684e-01e1-4d0f-9dd6-3285908a86d4" />
