### PR TITLE
rule: refine recommended config, scope, and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Add to your ESLint config:
 }
 ```
 
+### Recommended Config
+
+Use the plugin's recommended setup, which enables `no-hardcoded-jsx-text` as an error and `no-hardcoded-jsx-attributes` as a warning:
+
+```json
+{
+  "extends": ["plugin:i18n-rules/recommended"]
+}
+```
+
 ### JavaScript/TypeScript Config
 
 ```javascript
@@ -84,7 +94,6 @@ Detects hardcoded strings in user-visible JSX attributes that should be internat
 
 - **Accessibility**: `aria-label`, `aria-description`, `aria-valuetext`, `aria-roledescription`
 - **User-facing**: `title`, `alt`, `placeholder`
-- **Dynamic**: All `aria-*` attributes (auto-detected)
 
 #### ❌ Invalid
 

--- a/docs/rules/no-hardcoded-jsx-attributes.md
+++ b/docs/rules/no-hardcoded-jsx-attributes.md
@@ -8,9 +8,9 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 
 ## What it checks
 
-- Attributes: `aria-label`, `aria-description`, `aria-valuetext`, `aria-roledescription`, `title`, `alt`, `placeholder`, and other `aria-*` (excludes idrefs).
+- Attributes: `aria-label`, `aria-description`, `aria-valuetext`, `aria-roledescription`, `title`, `alt`, `placeholder`.
 - Static values: `attr="Hello"`, `attr={'Hello'}`, `attr={` + "`Hello`" + `}`.
-- Ignores: `aria-labelledby`, `aria-describedby` (ID refs), tags `title`, `style`, `script`, punctuation/emoji-only strings, and numeric-only strings.
+- Ignores: tags `title`, `style`, `script`, punctuation/emoji-only strings, and numeric-only strings.
 
 ## Examples
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,9 @@ module.exports = {
   },
   configs: {
     recommended: {
+      plugins: ["i18n-rules"],
       rules: {
+        "i18n-rules/no-hardcoded-jsx-text": "error",
         "i18n-rules/no-hardcoded-jsx-attributes": [
           "warn",
           {

--- a/lib/no-hardcoded-jsx-attributes.js
+++ b/lib/no-hardcoded-jsx-attributes.js
@@ -14,11 +14,6 @@ const TARGET_ATTRS = new Set([
   "alt",
   "placeholder",
 ]);
-const IDREF_ATTRS = new Set([
-  "aria-labelledby",
-  "aria-describedby",
-  "aria-hidden",
-]);
 exports.default = createRule({
   name: "no-hardcoded-jsx-attributes",
   meta: {
@@ -95,10 +90,8 @@ exports.default = createRule({
         // Resolve attribute name
         if (node.name.type !== "JSXIdentifier") return;
         const attrName = node.name.name;
-        // Only check target attributes; skip ID reference attributes
-        if (IDREF_ATTRS.has(attrName)) return;
-        if (!TARGET_ATTRS.has(attrName) && !attrName.startsWith("aria-"))
-          return;
+        // Only check a known allowlist of user-visible attributes
+        if (!TARGET_ATTRS.has(attrName)) return;
         // Skip on ignored tags
         const parentEl =
           node.parent &&

--- a/lib/no-hardcoded-jsx-text.js
+++ b/lib/no-hardcoded-jsx-text.js
@@ -3,7 +3,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 const utils_1 = require("@typescript-eslint/utils");
 const createRule = utils_1.ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/your-org/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`,
+    `https://github.com/camelohq/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`,
 );
 exports.default = createRule({
   name: "no-hardcoded-jsx-text",
@@ -12,7 +12,7 @@ exports.default = createRule({
     docs: {
       description:
         "Disallow hardcoded string literals in JSX — use t() or <Trans>.",
-      recommended: false,
+      recommended: "error",
     },
     messages: {
       noHardcoded:

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,9 @@ export = {
   },
   configs: {
     recommended: {
+      plugins: ["i18n-rules"],
       rules: {
+        "i18n-rules/no-hardcoded-jsx-text": "error",
         "i18n-rules/no-hardcoded-jsx-attributes": [
           "warn",
           {

--- a/src/no-hardcoded-jsx-attributes.ts
+++ b/src/no-hardcoded-jsx-attributes.ts
@@ -25,12 +25,6 @@ const TARGET_ATTRS = new Set([
   "placeholder",
 ]);
 
-const IDREF_ATTRS = new Set([
-  "aria-labelledby",
-  "aria-describedby",
-  "aria-hidden",
-]);
-
 export default createRule<Options, MessageIds>({
   name: "no-hardcoded-jsx-attributes",
   meta: {
@@ -114,10 +108,8 @@ export default createRule<Options, MessageIds>({
         if (node.name.type !== "JSXIdentifier") return;
         const attrName = node.name.name;
 
-        // Only check target attributes; skip ID reference attributes
-        if (IDREF_ATTRS.has(attrName)) return;
-        if (!TARGET_ATTRS.has(attrName) && !attrName.startsWith("aria-"))
-          return;
+        // Only check a known allowlist of user-visible attributes
+        if (!TARGET_ATTRS.has(attrName)) return;
 
         // Skip on ignored tags
         const parentEl =

--- a/src/no-hardcoded-jsx-text.ts
+++ b/src/no-hardcoded-jsx-text.ts
@@ -2,7 +2,7 @@ import { TSESTree, ESLintUtils } from "@typescript-eslint/utils";
 
 const createRule = ESLintUtils.RuleCreator(
   (name) =>
-    `https://github.com/your-org/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`,
+    `https://github.com/camelohq/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`,
 );
 
 type Options = [
@@ -21,7 +21,7 @@ export default createRule<Options, MessageIds>({
     docs: {
       description:
         "Disallow hardcoded string literals in JSX — use t() or <Trans>.",
-      recommended: false,
+      recommended: "error",
     },
     messages: {
       noHardcoded:

--- a/tests/no-hardcoded-jsx-attributes.test.js
+++ b/tests/no-hardcoded-jsx-attributes.test.js
@@ -16,31 +16,44 @@ const ruleTester = new ESLintUtils.RuleTester({
   },
 });
 
+// =============================================================================
+// Basic functionality tests
+// =============================================================================
+console.log("Running no-hardcoded-jsx-attributes basic functionality tests...");
+
 ruleTester.run("no-hardcoded-jsx-attributes", rule, {
   valid: [
-    // dynamic i18n usage
+    // Valid i18n usage
     { code: 'const C = () => <button aria-label={t("actions.save")} />;' },
-    // attributes not targeted
+
+    // Attributes not targeted
     { code: 'const C = () => <a href="/home" />;' },
     { code: 'const C = () => <div id="foo" className="bar" />;' },
-    // aria idrefs allowed
+
+    // ARIA idrefs allowed (no longer checked since PR scope refinement)
     { code: 'const C = () => <div aria-labelledby="heading-id" />;' },
     { code: 'const C = () => <div aria-describedby={"desc-id"} />;' },
-    // punctuation / emoji only
+
+    // Punctuation / emoji only
     { code: 'const C = () => <div title="— —" />;' },
     { code: 'const C = () => <div alt={"🙂"} />;' },
-    // numeric only -> ignored
+
+    // Numeric only -> ignored
     { code: 'const C = () => <div aria-label="123" />;' },
     { code: 'const C = () => <img alt={"999"} />;' },
     { code: "const C = () => <input placeholder={`42`} />;" },
     { code: 'const C = () => <div title="1" />;' },
-    // ignored tags
+
+    // Ignored tags
     { code: 'const C = () => <script title="Hello" />;' },
-    // default ignore list
+
+    // Default ignore list
     { code: 'const C = () => <div aria-label="404" />;' },
     { code: 'const C = () => <img alt="N/A" />;' },
     { code: 'const C = () => <div title={"404"} />;' },
     { code: "const C = () => <span aria-label={`N/A`} />;" },
+
+    // aria-hidden is not in TARGET_ATTRS allowlist anymore
     { code: 'const C = () => <span aria-hidden="true" />;' },
     { code: 'const C = () => <span aria-hidden="false" />;' },
   ],
@@ -76,7 +89,11 @@ ruleTester.run("no-hardcoded-jsx-attributes", rule, {
   ],
 });
 
-// Test with custom ignore list
+// =============================================================================
+// Option tests: ignoreLiterals
+// =============================================================================
+console.log("Running no-hardcoded-jsx-attributes ignoreLiterals tests...");
+
 ruleTester.run("no-hardcoded-jsx-attributes with custom ignore list", rule, {
   valid: [
     {
@@ -97,7 +114,11 @@ ruleTester.run("no-hardcoded-jsx-attributes with custom ignore list", rule, {
   ],
 });
 
-// Test case sensitivity
+// =============================================================================
+// Option tests: caseSensitive
+// =============================================================================
+console.log("Running no-hardcoded-jsx-attributes caseSensitive tests...");
+
 ruleTester.run("no-hardcoded-jsx-attributes case sensitivity", rule, {
   valid: [
     {
@@ -114,7 +135,11 @@ ruleTester.run("no-hardcoded-jsx-attributes case sensitivity", rule, {
   ],
 });
 
-// Test trim option
+// =============================================================================
+// Option tests: trim
+// =============================================================================
+console.log("Running no-hardcoded-jsx-attributes trim tests...");
+
 ruleTester.run("no-hardcoded-jsx-attributes trim option", rule, {
   valid: [
     {
@@ -131,13 +156,20 @@ ruleTester.run("no-hardcoded-jsx-attributes trim option", rule, {
   ],
 });
 
-// Test ignoreComponentsWithTitle option
+// =============================================================================
+// Option tests: ignoreComponentsWithTitle
+// =============================================================================
+console.log(
+  "Running no-hardcoded-jsx-attributes ignoreComponentsWithTitle tests...",
+);
+
 ruleTester.run("no-hardcoded-jsx-attributes ignoreComponentsWithTitle", rule, {
   valid: [
     // Default ignored components (Layout, SEO) with title props
     { code: 'const C = () => <Layout title="Page Title" />;' },
     { code: 'const C = () => <SEO title={"Page Title"} />;' },
     { code: "const C = () => <Layout title={`Page Title`} />;" },
+
     // Custom ignored components
     {
       code: 'const C = () => <PageWrapper title="Page Title" />;',
@@ -158,6 +190,7 @@ ruleTester.run("no-hardcoded-jsx-attributes ignoreComponentsWithTitle", rule, {
       code: 'const C = () => <div title={"Tooltip text"} />;',
       errors: [{ messageId: "noHardcodedAttr" }],
     },
+
     // Non-title attributes on ignored components should still be reported
     {
       code: 'const C = () => <Layout aria-label="Navigation" />;',
@@ -167,6 +200,7 @@ ruleTester.run("no-hardcoded-jsx-attributes ignoreComponentsWithTitle", rule, {
       code: 'const C = () => <SEO alt={"Description"} />;',
       errors: [{ messageId: "noHardcodedAttr" }],
     },
+
     // Components not in ignore list should be reported even with title
     {
       code: 'const C = () => <Button title="Click Me" />;',
@@ -176,4 +210,4 @@ ruleTester.run("no-hardcoded-jsx-attributes ignoreComponentsWithTitle", rule, {
   ],
 });
 
-console.log("Attribute rule tests executed successfully.");
+console.log("✓ no-hardcoded-jsx-attributes tests completed successfully.");

--- a/tests/no-hardcoded-jsx-text.test.js
+++ b/tests/no-hardcoded-jsx-text.test.js
@@ -78,3 +78,58 @@ ruleTester.run("no-hardcoded-jsx-text", rule, {
 });
 
 console.log("Rule tests executed.");
+
+// Test with custom ignore list
+ruleTester.run("no-hardcoded-jsx-text with custom ignore list", rule, {
+  valid: [
+    {
+      code: "const C = () => <div>SKU-123</div>;",
+      options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
+    },
+    {
+      code: 'const C = () => <p>{"v1.0"}</p>;',
+      options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
+    },
+  ],
+  invalid: [
+    {
+      code: "const C = () => <div>Hello</div>;",
+      options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
+      errors: [{ messageId: "noHardcoded" }],
+    },
+  ],
+});
+
+// Test case sensitivity
+ruleTester.run("no-hardcoded-jsx-text case sensitivity", rule, {
+  valid: [
+    {
+      code: "const C = () => <div>hello</div>;",
+      options: [{ ignoreLiterals: ["HELLO"], caseSensitive: false }],
+    },
+  ],
+  invalid: [
+    {
+      code: "const C = () => <div>hello</div>;",
+      options: [{ ignoreLiterals: ["HELLO"], caseSensitive: true }],
+      errors: [{ messageId: "noHardcoded" }],
+    },
+  ],
+});
+
+// Test trim option
+ruleTester.run("no-hardcoded-jsx-text trim option", rule, {
+  valid: [
+    {
+      code: "const C = () => <div>  hello  </div>;",
+      options: [{ ignoreLiterals: ["hello"], trim: true }],
+    },
+  ],
+  invalid: [
+    {
+      code: "const C = () => <div>  hello  </div>;",
+      options: [{ ignoreLiterals: ["hello"], trim: false }],
+      errors: [{ messageId: "noHardcoded" }],
+    },
+  ],
+});

--- a/tests/no-hardcoded-jsx-text.test.js
+++ b/tests/no-hardcoded-jsx-text.test.js
@@ -16,30 +16,45 @@ const ruleTester = new ESLintUtils.RuleTester({
   },
 });
 
+// =============================================================================
+// Basic functionality tests
+// =============================================================================
+console.log("Running no-hardcoded-jsx-text basic functionality tests...");
+
 ruleTester.run("no-hardcoded-jsx-text", rule, {
   valid: [
+    // Valid i18n usage
     { code: 'const C = () => <div>{t("home.title")}</div>;' },
     { code: 'const C = () => <Trans>{t("stats.clicks")} {count}</Trans>;' },
+
+    // Whitespace only
     { code: 'const C = () => <div>{" "}</div>;' },
+
+    // Special tags (ignored)
     { code: 'const C = () => <style>{".foo{color:red}"}</style>;' },
     { code: "const C = () => <title>Home</title>;" },
+    { code: "const C = () => <script>var a=1;</script>;" },
+
     // Punctuation / symbols only -> ignored (no a-zA-Z0-9)
     { code: "const C = () => <div>— … • ✓</div>;" },
+
     // Emoji only -> ignored
     { code: "const C = () => <div>🙂🙂</div>;" },
+
     // Numeric only -> ignored
     { code: "const C = () => <div>123</div>;" },
     { code: "const C = () => <div>1</div>;" },
     { code: "const C = () => <div>999</div>;" },
+
     // Attribute text is not JSXText -> not reported by this rule
     { code: 'const C = () => <div aria-label="Hello" />;' },
-    // Script tag content ignored by rule
-    { code: "const C = () => <script>var a=1;</script>;" },
+
     // Expression containers: dynamic -> allowed
     { code: 'const C = () => <div>{t("home.title")}</div>;' },
     { code: "const C = () => <div>{`Hello ${name}`}</div>;" },
     { code: 'const C = () => <title>{"Home"}</title>;' },
     { code: 'const C = () => <div>{"🙂"}</div>;' },
+
     // Numeric only in expression containers -> ignored
     { code: 'const C = () => <div>{"123"}</div>;' },
     { code: "const C = () => <div>{`999`}</div>;" },
@@ -61,6 +76,7 @@ ruleTester.run("no-hardcoded-jsx-text", rule, {
       code: "const C = () => <p>Hi — 2024</p>;",
       errors: [{ messageId: "noHardcoded" }],
     },
+
     // Expression containers: static strings -> disallow
     {
       code: 'const C = () => <div>{"Hello"}</div>;',
@@ -77,9 +93,11 @@ ruleTester.run("no-hardcoded-jsx-text", rule, {
   ],
 });
 
-console.log("Rule tests executed.");
+// =============================================================================
+// Option tests: ignoreLiterals
+// =============================================================================
+console.log("Running no-hardcoded-jsx-text ignoreLiterals tests...");
 
-// Test with custom ignore list
 ruleTester.run("no-hardcoded-jsx-text with custom ignore list", rule, {
   valid: [
     {
@@ -100,7 +118,11 @@ ruleTester.run("no-hardcoded-jsx-text with custom ignore list", rule, {
   ],
 });
 
-// Test case sensitivity
+// =============================================================================
+// Option tests: caseSensitive
+// =============================================================================
+console.log("Running no-hardcoded-jsx-text caseSensitive tests...");
+
 ruleTester.run("no-hardcoded-jsx-text case sensitivity", rule, {
   valid: [
     {
@@ -117,7 +139,11 @@ ruleTester.run("no-hardcoded-jsx-text case sensitivity", rule, {
   ],
 });
 
-// Test trim option
+// =============================================================================
+// Option tests: trim
+// =============================================================================
+console.log("Running no-hardcoded-jsx-text trim tests...");
+
 ruleTester.run("no-hardcoded-jsx-text trim option", rule, {
   valid: [
     {
@@ -133,3 +159,5 @@ ruleTester.run("no-hardcoded-jsx-text trim option", rule, {
     },
   ],
 });
+
+console.log("✓ no-hardcoded-jsx-text tests completed successfully.");


### PR DESCRIPTION
# Summary
This PR refines the plugin’s recommended config, tightens attribute scope to reduce false positives, and aligns documentation and tests.

### Changes
- Enable `no-hardcoded-jsx-text` in recommended config (set to **error**)
- Add `plugins: ['i18n-rules']` to recommended config
- Narrow `no-hardcoded-jsx-attributes` to an allowlist:
  - `aria-label`, `aria-description`, `aria-valuetext`, `aria-roledescription`
  - `title`, `alt`, `placeholder`
- Normalize `RuleCreator` docs URLs to `camelohq`
- Add option tests for text rule (`ignoreLiterals`, `caseSensitive`, `trim`)
- Update README and rule docs with recommended config usage

# Motivation
- Prevent false positives on non–user-visible ARIA attributes
- Keep recommended config consistent across README and rule metadata
- Ensure documentation URLs point to the correct org (`camelohq`)
