### PR TITLE
feat: migrate from tsup to tsdown bundler

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,32 +1,32 @@
-import * as _typescript_eslint_utils_dist_ts_eslint_Rule from '@typescript-eslint/utils/dist/ts-eslint/Rule';
+import * as _typescript_eslint_utils_dist_ts_eslint_Rule0 from "@typescript-eslint/utils/dist/ts-eslint/Rule";
 
+//#region src/index.d.ts
 declare const _default: {
-    rules: {
-        "no-hardcoded-jsx-text": _typescript_eslint_utils_dist_ts_eslint_Rule.RuleModule<"noHardcoded", [{
-            ignoreLiterals?: string[] | undefined;
-            caseSensitive?: boolean | undefined;
-            trim?: boolean | undefined;
-        }], _typescript_eslint_utils_dist_ts_eslint_Rule.RuleListener>;
-        "no-hardcoded-jsx-attributes": _typescript_eslint_utils_dist_ts_eslint_Rule.RuleModule<"noHardcodedAttr", [{
-            ignoreLiterals?: string[] | undefined;
-            caseSensitive?: boolean | undefined;
-            trim?: boolean | undefined;
-            ignoreComponentsWithTitle?: string[] | undefined;
-        }], _typescript_eslint_utils_dist_ts_eslint_Rule.RuleListener>;
+  rules: {
+    "no-hardcoded-jsx-text": _typescript_eslint_utils_dist_ts_eslint_Rule0.RuleModule<"noHardcoded", [{
+      ignoreLiterals?: string[] | undefined;
+      caseSensitive?: boolean | undefined;
+      trim?: boolean | undefined;
+    }], _typescript_eslint_utils_dist_ts_eslint_Rule0.RuleListener>;
+    "no-hardcoded-jsx-attributes": _typescript_eslint_utils_dist_ts_eslint_Rule0.RuleModule<"noHardcodedAttr", [{
+      ignoreLiterals?: string[] | undefined;
+      caseSensitive?: boolean | undefined;
+      trim?: boolean | undefined;
+      ignoreComponentsWithTitle?: string[] | undefined;
+    }], _typescript_eslint_utils_dist_ts_eslint_Rule0.RuleListener>;
+  };
+  configs: {
+    recommended: {
+      plugins: string[];
+      rules: {
+        "i18n-rules/no-hardcoded-jsx-text": string;
+        "i18n-rules/no-hardcoded-jsx-attributes": (string | {
+          ignoreLiterals: string[];
+          caseSensitive: boolean;
+          trim: boolean;
+        })[];
+      };
     };
-    configs: {
-        recommended: {
-            plugins: string[];
-            rules: {
-                "i18n-rules/no-hardcoded-jsx-text": string;
-                "i18n-rules/no-hardcoded-jsx-attributes": (string | {
-                    ignoreLiterals: string[];
-                    caseSensitive: boolean;
-                    trim: boolean;
-                })[];
-            };
-        };
-    };
+  };
 };
-
-export { _default as default };
+export = _default;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,313 +1,314 @@
-"use strict";
-
-// src/no-hardcoded-jsx-text.ts
-var import_utils = require("@typescript-eslint/utils");
-var createRule = import_utils.ESLintUtils.RuleCreator(
-  (name) => `https://github.com/camelohq/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`
-);
-var no_hardcoded_jsx_text_default = createRule({
-  name: "no-hardcoded-jsx-text",
-  meta: {
-    type: "problem",
-    docs: {
-      description: "Disallow hardcoded string literals in JSX \u2014 use t() or <Trans>.",
-      recommended: "error"
-    },
-    messages: {
-      noHardcoded: "Avoid hardcoded string '{{ text }}' in JSX \u2014 use t() or <Trans>."
-    },
-    schema: [
-      {
-        type: "object",
-        properties: {
-          ignoreLiterals: {
-            type: "array",
-            items: { type: "string" },
-            default: ["404", "N/A"]
-          },
-          caseSensitive: {
-            type: "boolean",
-            default: false
-          },
-          trim: {
-            type: "boolean",
-            default: true
-          }
-        },
-        additionalProperties: false
-      }
-    ]
-  },
-  defaultOptions: [
-    {
-      ignoreLiterals: ["404", "N/A"],
-      caseSensitive: false,
-      trim: true
-    }
-  ],
-  create(context) {
-    const options = context.options[0] || {};
-    const {
-      ignoreLiterals = ["404", "N/A"],
-      caseSensitive = false,
-      trim: shouldTrim = true
-    } = options;
-    const shouldIgnoreString = (text) => {
-      let normalizedText = text;
-      if (shouldTrim) {
-        normalizedText = normalizedText.trim();
-      }
-      return ignoreLiterals.some((ignored) => {
-        let normalizedIgnored = ignored;
-        let textToCompare = normalizedText;
-        if (!caseSensitive) {
-          normalizedIgnored = normalizedIgnored.toLowerCase();
-          textToCompare = textToCompare.toLowerCase();
-        }
-        return textToCompare === normalizedIgnored;
-      });
-    };
-    const isInsideTransComponent = (node) => {
-      let current = node.parent;
-      while (current) {
-        if (current.type === "JSXElement" && current.openingElement.name.type === "JSXIdentifier" && current.openingElement.name.name === "Trans") {
-          return true;
-        }
-        current = current.parent;
-      }
-      return false;
-    };
-    return {
-      JSXText(node) {
-        const raw = node.value;
-        const value = raw.trim();
-        if (!value) return;
-        if (!/[a-zA-Z0-9]/.test(value)) return;
-        if (isInsideTransComponent(node)) return;
-        const parent = node.parent;
-        if ((parent == null ? void 0 : parent.type) === "JSXElement" && parent.openingElement.name.type === "JSXIdentifier") {
-          const tagName = parent.openingElement.name.name;
-          const ignoredTags = ["title", "style", "script"];
-          if (ignoredTags.includes(tagName)) return;
-        }
-        if (/^[0-9]+$/.test(value)) return;
-        if (shouldIgnoreString(raw)) return;
-        context.report({
-          node,
-          messageId: "noHardcoded",
-          data: { text: value }
-        });
-      },
-      JSXExpressionContainer(node) {
-        if (isInsideTransComponent(node)) return;
-        const parent = node.parent;
-        if ((parent == null ? void 0 : parent.type) === "JSXElement" && parent.openingElement.name.type === "JSXIdentifier") {
-          const tagName = parent.openingElement.name.name;
-          const ignoredTags = ["title", "style", "script"];
-          if (ignoredTags.includes(tagName)) return;
-        }
-        const expr = node.expression;
-        if (expr.type === "Literal" && typeof expr.value === "string") {
-          const text = expr.value.trim();
-          if (!text) return;
-          if (!/[a-zA-Z0-9]/.test(text)) return;
-          if (/^[0-9]+$/.test(text)) return;
-          if (shouldIgnoreString(expr.value)) return;
-          context.report({
-            node: expr,
-            messageId: "noHardcoded",
-            data: { text }
-          });
-          return;
-        }
-        if (expr.type === "TemplateLiteral" && expr.expressions.length === 0) {
-          const cooked = expr.quasis.map((q) => {
-            var _a;
-            return (_a = q.value.cooked) != null ? _a : "";
-          }).join("");
-          const text = cooked.trim();
-          if (!text) return;
-          if (!/[a-zA-Z0-9]/.test(text)) return;
-          if (/^[0-9]+$/.test(text)) return;
-          if (shouldIgnoreString(cooked)) return;
-          context.report({
-            node: expr,
-            messageId: "noHardcoded",
-            data: { text }
-          });
-          return;
-        }
-      }
-    };
-  }
-});
-
-// src/no-hardcoded-jsx-attributes.ts
-var import_utils2 = require("@typescript-eslint/utils");
-var createRule2 = import_utils2.ESLintUtils.RuleCreator(
-  (name) => `https://github.com/camelohq/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`
-);
-var TARGET_ATTRS = /* @__PURE__ */ new Set([
-  "aria-label",
-  "aria-description",
-  "aria-valuetext",
-  "aria-roledescription",
-  "title",
-  "alt",
-  "placeholder"
-]);
-var no_hardcoded_jsx_attributes_default = createRule2({
-  name: "no-hardcoded-jsx-attributes",
-  meta: {
-    type: "problem",
-    docs: {
-      description: "Disallow hardcoded string literals in user-visible JSX attributes \u2014 use t() instead.",
-      recommended: false
-    },
-    messages: {
-      noHardcodedAttr: "Avoid hardcoded string '{{ text }}' in JSX attribute '{{ attr }}' \u2014 use t()."
-    },
-    schema: [
-      {
-        type: "object",
-        properties: {
-          ignoreLiterals: {
-            type: "array",
-            items: { type: "string" },
-            default: ["404", "N/A"]
-          },
-          caseSensitive: {
-            type: "boolean",
-            default: false
-          },
-          trim: {
-            type: "boolean",
-            default: true
-          },
-          ignoreComponentsWithTitle: {
-            type: "array",
-            items: { type: "string" },
-            default: ["Layout", "SEO"]
-          }
-        },
-        additionalProperties: false
-      }
-    ]
-  },
-  defaultOptions: [
-    {
-      ignoreLiterals: ["404", "N/A"],
-      caseSensitive: false,
-      trim: true,
-      ignoreComponentsWithTitle: ["Layout", "SEO"]
-    }
-  ],
-  create(context) {
-    const options = context.options[0] || {};
-    const {
-      ignoreLiterals = ["404", "N/A"],
-      caseSensitive = false,
-      trim: shouldTrim = true,
-      ignoreComponentsWithTitle = ["Layout", "SEO"]
-    } = options;
-    const shouldIgnoreString = (text) => {
-      let normalizedText = text;
-      if (shouldTrim) {
-        normalizedText = normalizedText.trim();
-      }
-      return ignoreLiterals.some((ignored) => {
-        let normalizedIgnored = ignored;
-        let textToCompare = normalizedText;
-        if (!caseSensitive) {
-          normalizedIgnored = normalizedIgnored.toLowerCase();
-          textToCompare = textToCompare.toLowerCase();
-        }
-        return textToCompare === normalizedIgnored;
-      });
-    };
-    return {
-      JSXAttribute(node) {
-        if (node.name.type !== "JSXIdentifier") return;
-        const attrName = node.name.name;
-        if (!TARGET_ATTRS.has(attrName)) return;
-        const parentEl = node.parent && node.parent.type === "JSXOpeningElement" && node.parent.name.type === "JSXIdentifier" ? node.parent.name.name : void 0;
-        const ignoredTags = ["title", "style", "script"];
-        if (parentEl && ignoredTags.includes(parentEl)) return;
-        if (attrName === "title" && parentEl && ignoreComponentsWithTitle.includes(parentEl))
-          return;
-        const value = node.value;
-        if (!value) return;
-        if (value.type === "Literal" && typeof value.value === "string") {
-          const text = value.value.trim();
-          if (!text) return;
-          if (!/[a-zA-Z0-9]/.test(text)) return;
-          if (/^[0-9]+$/.test(text)) return;
-          if (shouldIgnoreString(value.value)) return;
-          context.report({
-            node: value,
-            messageId: "noHardcodedAttr",
-            data: { text, attr: attrName }
-          });
-          return;
-        }
-        if (value.type === "JSXExpressionContainer") {
-          const expr = value.expression;
-          if (expr.type === "Literal" && typeof expr.value === "string") {
-            const text = expr.value.trim();
-            if (!text) return;
-            if (!/[a-zA-Z0-9]/.test(text)) return;
-            if (/^[0-9]+$/.test(text)) return;
-            if (shouldIgnoreString(expr.value)) return;
-            context.report({
-              node: expr,
-              messageId: "noHardcodedAttr",
-              data: { text, attr: attrName }
-            });
-            return;
-          }
-          if (expr.type === "TemplateLiteral" && expr.expressions.length === 0) {
-            const cooked = expr.quasis.map((q) => {
-              var _a;
-              return (_a = q.value.cooked) != null ? _a : "";
-            }).join("");
-            const text = cooked.trim();
-            if (!text) return;
-            if (!/[a-zA-Z0-9]/.test(text)) return;
-            if (/^[0-9]+$/.test(text)) return;
-            if (shouldIgnoreString(cooked)) return;
-            context.report({
-              node: expr,
-              messageId: "noHardcodedAttr",
-              data: { text, attr: attrName }
-            });
-            return;
-          }
-        }
-      }
-    };
-  }
-});
-
-// src/index.ts
-module.exports = {
-  rules: {
-    "no-hardcoded-jsx-text": no_hardcoded_jsx_text_default,
-    "no-hardcoded-jsx-attributes": no_hardcoded_jsx_attributes_default
-  },
-  configs: {
-    recommended: {
-      plugins: ["i18n-rules"],
-      rules: {
-        "i18n-rules/no-hardcoded-jsx-text": "error",
-        "i18n-rules/no-hardcoded-jsx-attributes": [
-          "warn",
-          {
-            ignoreLiterals: ["404", "N/A", "SKU-0001"],
-            caseSensitive: false,
-            trim: true
-          }
-        ]
-      }
-    }
-  }
+//#region rolldown:runtime
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __copyProps = (to, from, except, desc) => {
+	if (from && typeof from === "object" || typeof from === "function") for (var keys = __getOwnPropNames(from), i = 0, n = keys.length, key; i < n; i++) {
+		key = keys[i];
+		if (!__hasOwnProp.call(to, key) && key !== except) __defProp(to, key, {
+			get: ((k) => from[k]).bind(null, key),
+			enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable
+		});
+	}
+	return to;
 };
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", {
+	value: mod,
+	enumerable: true
+}) : target, mod));
+
+//#endregion
+let __typescript_eslint_utils = require("@typescript-eslint/utils");
+__typescript_eslint_utils = __toESM(__typescript_eslint_utils);
+
+//#region src/no-hardcoded-jsx-text.ts
+const createRule$1 = __typescript_eslint_utils.ESLintUtils.RuleCreator((name) => `https://github.com/camelohq/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`);
+var no_hardcoded_jsx_text_default = createRule$1({
+	name: "no-hardcoded-jsx-text",
+	meta: {
+		type: "problem",
+		docs: {
+			description: "Disallow hardcoded string literals in JSX — use t() or <Trans>.",
+			recommended: "error"
+		},
+		messages: { noHardcoded: "Avoid hardcoded string '{{ text }}' in JSX — use t() or <Trans>." },
+		schema: [{
+			type: "object",
+			properties: {
+				ignoreLiterals: {
+					type: "array",
+					items: { type: "string" },
+					default: ["404", "N/A"]
+				},
+				caseSensitive: {
+					type: "boolean",
+					default: false
+				},
+				trim: {
+					type: "boolean",
+					default: true
+				}
+			},
+			additionalProperties: false
+		}]
+	},
+	defaultOptions: [{
+		ignoreLiterals: ["404", "N/A"],
+		caseSensitive: false,
+		trim: true
+	}],
+	create(context) {
+		const { ignoreLiterals = ["404", "N/A"], caseSensitive = false, trim: shouldTrim = true } = context.options[0] || {};
+		const shouldIgnoreString = (text) => {
+			let normalizedText = text;
+			if (shouldTrim) normalizedText = normalizedText.trim();
+			return ignoreLiterals.some((ignored) => {
+				let normalizedIgnored = ignored;
+				let textToCompare = normalizedText;
+				if (!caseSensitive) {
+					normalizedIgnored = normalizedIgnored.toLowerCase();
+					textToCompare = textToCompare.toLowerCase();
+				}
+				return textToCompare === normalizedIgnored;
+			});
+		};
+		const isInsideTransComponent = (node) => {
+			let current = node.parent;
+			while (current) {
+				if (current.type === "JSXElement" && current.openingElement.name.type === "JSXIdentifier" && current.openingElement.name.name === "Trans") return true;
+				current = current.parent;
+			}
+			return false;
+		};
+		return {
+			JSXText(node) {
+				const raw = node.value;
+				const value = raw.trim();
+				if (!value) return;
+				if (!/[a-zA-Z0-9]/.test(value)) return;
+				if (isInsideTransComponent(node)) return;
+				const parent = node.parent;
+				if (parent?.type === "JSXElement" && parent.openingElement.name.type === "JSXIdentifier") {
+					const tagName = parent.openingElement.name.name;
+					if ([
+						"title",
+						"style",
+						"script"
+					].includes(tagName)) return;
+				}
+				if (/^[0-9]+$/.test(value)) return;
+				if (shouldIgnoreString(raw)) return;
+				context.report({
+					node,
+					messageId: "noHardcoded",
+					data: { text: value }
+				});
+			},
+			JSXExpressionContainer(node) {
+				if (isInsideTransComponent(node)) return;
+				const parent = node.parent;
+				if (parent?.type === "JSXElement" && parent.openingElement.name.type === "JSXIdentifier") {
+					const tagName = parent.openingElement.name.name;
+					if ([
+						"title",
+						"style",
+						"script"
+					].includes(tagName)) return;
+				}
+				const expr = node.expression;
+				if (expr.type === "Literal" && typeof expr.value === "string") {
+					const text = expr.value.trim();
+					if (!text) return;
+					if (!/[a-zA-Z0-9]/.test(text)) return;
+					if (/^[0-9]+$/.test(text)) return;
+					if (shouldIgnoreString(expr.value)) return;
+					context.report({
+						node: expr,
+						messageId: "noHardcoded",
+						data: { text }
+					});
+					return;
+				}
+				if (expr.type === "TemplateLiteral" && expr.expressions.length === 0) {
+					const cooked = expr.quasis.map((q) => q.value.cooked ?? "").join("");
+					const text = cooked.trim();
+					if (!text) return;
+					if (!/[a-zA-Z0-9]/.test(text)) return;
+					if (/^[0-9]+$/.test(text)) return;
+					if (shouldIgnoreString(cooked)) return;
+					context.report({
+						node: expr,
+						messageId: "noHardcoded",
+						data: { text }
+					});
+					return;
+				}
+			}
+		};
+	}
+});
+
+//#endregion
+//#region src/no-hardcoded-jsx-attributes.ts
+const createRule = __typescript_eslint_utils.ESLintUtils.RuleCreator((name) => `https://github.com/camelohq/eslint-plugin-i18n-rules/blob/main/docs/rules/${name}.md`);
+const TARGET_ATTRS = new Set([
+	"aria-label",
+	"aria-description",
+	"aria-valuetext",
+	"aria-roledescription",
+	"title",
+	"alt",
+	"placeholder"
+]);
+var no_hardcoded_jsx_attributes_default = createRule({
+	name: "no-hardcoded-jsx-attributes",
+	meta: {
+		type: "problem",
+		docs: {
+			description: "Disallow hardcoded string literals in user-visible JSX attributes — use t() instead.",
+			recommended: false
+		},
+		messages: { noHardcodedAttr: "Avoid hardcoded string '{{ text }}' in JSX attribute '{{ attr }}' — use t()." },
+		schema: [{
+			type: "object",
+			properties: {
+				ignoreLiterals: {
+					type: "array",
+					items: { type: "string" },
+					default: ["404", "N/A"]
+				},
+				caseSensitive: {
+					type: "boolean",
+					default: false
+				},
+				trim: {
+					type: "boolean",
+					default: true
+				},
+				ignoreComponentsWithTitle: {
+					type: "array",
+					items: { type: "string" },
+					default: ["Layout", "SEO"]
+				}
+			},
+			additionalProperties: false
+		}]
+	},
+	defaultOptions: [{
+		ignoreLiterals: ["404", "N/A"],
+		caseSensitive: false,
+		trim: true,
+		ignoreComponentsWithTitle: ["Layout", "SEO"]
+	}],
+	create(context) {
+		const { ignoreLiterals = ["404", "N/A"], caseSensitive = false, trim: shouldTrim = true, ignoreComponentsWithTitle = ["Layout", "SEO"] } = context.options[0] || {};
+		const shouldIgnoreString = (text) => {
+			let normalizedText = text;
+			if (shouldTrim) normalizedText = normalizedText.trim();
+			return ignoreLiterals.some((ignored) => {
+				let normalizedIgnored = ignored;
+				let textToCompare = normalizedText;
+				if (!caseSensitive) {
+					normalizedIgnored = normalizedIgnored.toLowerCase();
+					textToCompare = textToCompare.toLowerCase();
+				}
+				return textToCompare === normalizedIgnored;
+			});
+		};
+		return { JSXAttribute(node) {
+			if (node.name.type !== "JSXIdentifier") return;
+			const attrName = node.name.name;
+			if (!TARGET_ATTRS.has(attrName)) return;
+			const parentEl = node.parent && node.parent.type === "JSXOpeningElement" && node.parent.name.type === "JSXIdentifier" ? node.parent.name.name : void 0;
+			if (parentEl && [
+				"title",
+				"style",
+				"script"
+			].includes(parentEl)) return;
+			if (attrName === "title" && parentEl && ignoreComponentsWithTitle.includes(parentEl)) return;
+			const value = node.value;
+			if (!value) return;
+			if (value.type === "Literal" && typeof value.value === "string") {
+				const text = value.value.trim();
+				if (!text) return;
+				if (!/[a-zA-Z0-9]/.test(text)) return;
+				if (/^[0-9]+$/.test(text)) return;
+				if (shouldIgnoreString(value.value)) return;
+				context.report({
+					node: value,
+					messageId: "noHardcodedAttr",
+					data: {
+						text,
+						attr: attrName
+					}
+				});
+				return;
+			}
+			if (value.type === "JSXExpressionContainer") {
+				const expr = value.expression;
+				if (expr.type === "Literal" && typeof expr.value === "string") {
+					const text = expr.value.trim();
+					if (!text) return;
+					if (!/[a-zA-Z0-9]/.test(text)) return;
+					if (/^[0-9]+$/.test(text)) return;
+					if (shouldIgnoreString(expr.value)) return;
+					context.report({
+						node: expr,
+						messageId: "noHardcodedAttr",
+						data: {
+							text,
+							attr: attrName
+						}
+					});
+					return;
+				}
+				if (expr.type === "TemplateLiteral" && expr.expressions.length === 0) {
+					const cooked = expr.quasis.map((q) => q.value.cooked ?? "").join("");
+					const text = cooked.trim();
+					if (!text) return;
+					if (!/[a-zA-Z0-9]/.test(text)) return;
+					if (/^[0-9]+$/.test(text)) return;
+					if (shouldIgnoreString(cooked)) return;
+					context.report({
+						node: expr,
+						messageId: "noHardcodedAttr",
+						data: {
+							text,
+							attr: attrName
+						}
+					});
+					return;
+				}
+			}
+		} };
+	}
+});
+
+//#endregion
+//#region src/index.ts
+module.exports = {
+	rules: {
+		"no-hardcoded-jsx-text": no_hardcoded_jsx_text_default,
+		"no-hardcoded-jsx-attributes": no_hardcoded_jsx_attributes_default
+	},
+	configs: { recommended: {
+		plugins: ["i18n-rules"],
+		rules: {
+			"i18n-rules/no-hardcoded-jsx-text": "error",
+			"i18n-rules/no-hardcoded-jsx-attributes": ["warn", {
+				ignoreLiterals: [
+					"404",
+					"N/A",
+					"SKU-0001"
+				],
+				caseSensitive: false,
+				trim: true
+			}]
+		}
+	} }
+};
+
+//#endregion

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lib"
   ],
   "scripts": {
-    "build": "tsup",
+    "build": "tsdown",
     "build:dev": "tsc",
     "lint": "eslint . --ext .ts",
     "test": "npm run build && node tests/index.js",
@@ -23,7 +23,7 @@
     "@typescript-eslint/utils": "^5.62.0",
     "eslint": "^8.0.0",
     "prettier": "^3.6.2",
-    "tsup": "^8.5.0",
+    "tsdown": "^0.15.3",
     "typescript": "~5.0.4"
   },
   "peerDependencies": {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'tsup';
+import { defineConfig } from 'tsdown';
 
 export default defineConfig({
   entry: ['src/index.ts'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,193 @@
 # yarn lockfile v1
 
 
+"@babel/generator@^7.28.3":
+  version "7.28.3"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.28.3.tgz#9626c1741c650cbac39121694a0f2d7451b8ef3e"
+  integrity sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==
+  dependencies:
+    "@babel/parser" "^7.28.3"
+    "@babel/types" "^7.28.2"
+    "@jridgewell/gen-mapping" "^0.3.12"
+    "@jridgewell/trace-mapping" "^0.3.28"
+    jsesc "^3.0.2"
+
+"@babel/helper-string-parser@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz#54da796097ab19ce67ed9f88b47bb2ec49367687"
+  integrity sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==
+
+"@babel/helper-validator-identifier@^7.27.1":
+  version "7.27.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz#a7054dcc145a967dd4dc8fee845a57c1316c9df8"
+  integrity sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==
+
+"@babel/parser@^7.28.0", "@babel/parser@^7.28.3", "@babel/parser@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.28.4.tgz#da25d4643532890932cc03f7705fe19637e03fa8"
+  integrity sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==
+  dependencies:
+    "@babel/types" "^7.28.4"
+
+"@babel/types@^7.28.2", "@babel/types@^7.28.4":
+  version "7.28.4"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.4.tgz#0a4e618f4c60a7cd6c11cb2d48060e4dbe38ac3a"
+  integrity sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.27.1"
+
+"@emnapi/core@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.5.0.tgz#85cd84537ec989cebb2343606a1ee663ce4edaf0"
+  integrity sha512-sbP8GzB1WDzacS8fgNPpHlp6C9VZe+SJP3F90W9rLemaQj2PzIuTEl1qDOYQf58YIpyjViI24y9aPWCjEzY2cg==
+  dependencies:
+    "@emnapi/wasi-threads" "1.1.0"
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.5.0":
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.5.0.tgz#9aebfcb9b17195dce3ab53c86787a6b7d058db73"
+  integrity sha512-97/BJ3iXHww3djw6hYIfErCZFee7qCtrneuLa20UXFCOTCfBM2cvQHjWJ2EG0s0MtdNwInarqCTz35i4wWXHsQ==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/wasi-threads@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz#60b2102fddc9ccb78607e4a3cf8403ea69be41bf"
+  integrity sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==
+  dependencies:
+    tslib "^2.4.0"
+
+"@esbuild/aix-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz#ee6b7163a13528e099ecf562b972f2bcebe0aa97"
+  integrity sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==
+
+"@esbuild/android-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz#115fc76631e82dd06811bfaf2db0d4979c16e2cb"
+  integrity sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==
+
+"@esbuild/android-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.25.10.tgz#8d5811912da77f615398611e5bbc1333fe321aa9"
+  integrity sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==
+
+"@esbuild/android-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.25.10.tgz#e3e96516b2d50d74105bb92594c473e30ddc16b1"
+  integrity sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==
+
 "@esbuild/darwin-arm64@0.25.10":
   version "0.25.10"
   resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz"
   integrity sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==
+
+"@esbuild/darwin-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz#99ae82347fbd336fc2d28ffd4f05694e6e5b723d"
+  integrity sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==
+
+"@esbuild/freebsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz#0c6d5558a6322b0bdb17f7025c19bd7d2359437d"
+  integrity sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==
+
+"@esbuild/freebsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz#8c35873fab8c0857a75300a3dcce4324ca0b9844"
+  integrity sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==
+
+"@esbuild/linux-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz#3edc2f87b889a15b4cedaf65f498c2bed7b16b90"
+  integrity sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==
+
+"@esbuild/linux-arm@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz#86501cfdfb3d110176d80c41b27ed4611471cde7"
+  integrity sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==
+
+"@esbuild/linux-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz#e6589877876142537c6864680cd5d26a622b9d97"
+  integrity sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==
+
+"@esbuild/linux-loong64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz#11119e18781f136d8083ea10eb6be73db7532de8"
+  integrity sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==
+
+"@esbuild/linux-mips64el@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz#3052f5436b0c0c67a25658d5fc87f045e7def9e6"
+  integrity sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==
+
+"@esbuild/linux-ppc64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz#2f098920ee5be2ce799f35e367b28709925a8744"
+  integrity sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==
+
+"@esbuild/linux-riscv64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz#fa51d7fd0a22a62b51b4b94b405a3198cf7405dd"
+  integrity sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==
+
+"@esbuild/linux-s390x@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz#a27642e36fc282748fdb38954bd3ef4f85791e8a"
+  integrity sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==
+
+"@esbuild/linux-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz#9d9b09c0033d17529570ced6d813f98315dfe4e9"
+  integrity sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==
+
+"@esbuild/netbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz#25c09a659c97e8af19e3f2afd1c9190435802151"
+  integrity sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==
+
+"@esbuild/netbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz#7fa5f6ffc19be3a0f6f5fd32c90df3dc2506937a"
+  integrity sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==
+
+"@esbuild/openbsd-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz#8faa6aa1afca0c6d024398321d6cb1c18e72a1c3"
+  integrity sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==
+
+"@esbuild/openbsd-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz#a42979b016f29559a8453d32440d3c8cd420af5e"
+  integrity sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==
+
+"@esbuild/openharmony-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz#fd87bfeadd7eeb3aa384bbba907459ffa3197cb1"
+  integrity sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==
+
+"@esbuild/sunos-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz#3a18f590e36cb78ae7397976b760b2b8c74407f4"
+  integrity sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==
+
+"@esbuild/win32-arm64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz#e71741a251e3fd971408827a529d2325551f530c"
+  integrity sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==
+
+"@esbuild/win32-ia32@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz#c6f010b5d3b943d8901a0c87ea55f93b8b54bf94"
+  integrity sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==
+
+"@esbuild/win32-x64@0.25.10":
+  version "0.25.10"
+  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz#e4b3e255a1b4aea84f6e1d2ae0b73f826c3785bd"
+  integrity sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==
 
 "@eslint-community/eslint-utils@^4.2.0":
   version "4.7.0"
@@ -70,7 +253,7 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@jridgewell/gen-mapping@^0.3.2":
+"@jridgewell/gen-mapping@^0.3.12", "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.13"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
   integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
@@ -88,13 +271,22 @@
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
-"@jridgewell/trace-mapping@^0.3.24":
+"@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.28":
   version "0.3.31"
   resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
   integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
   dependencies:
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@napi-rs/wasm-runtime@^1.0.5":
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.5.tgz#1fc8952d993d476c9e57999a3b886239119ce476"
+  integrity sha512-TBr9Cf9onSAS2LQ2+QHx6XcC6h9+RIzJgbqG3++9TUZSH204AwEy5jg3BTQ0VATsyoGj4ee49tN/y6rvaOOtcg==
+  dependencies:
+    "@emnapi/core" "^1.5.0"
+    "@emnapi/runtime" "^1.5.0"
+    "@tybys/wasm-util" "^0.10.1"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -104,7 +296,7 @@
     "@nodelib/fs.stat" "2.0.5"
     run-parallel "^1.1.9"
 
-"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+"@nodelib/fs.stat@2.0.5", "@nodelib/fs.stat@^2.0.2":
   version "2.0.5"
   resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
   integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
@@ -117,15 +309,216 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@oxc-project/types@=0.89.0":
+  version "0.89.0"
+  resolved "https://registry.yarnpkg.com/@oxc-project/types/-/types-0.89.0.tgz#8c78b52c9754382d1c92c243aea75fdca642859a"
+  integrity sha512-yuo+ECPIW5Q9mSeNmCDC2im33bfKuwW18mwkaHMQh8KakHYDzj4ci/q7wxf2qS3dMlVVCIyrs3kFtH5LmnlYnw==
+
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
   resolved "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz"
   integrity sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==
 
+"@quansync/fs@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@quansync/fs/-/fs-0.1.5.tgz#8d89bc7add93f9b77e053ff8293d5ca82199fb1f"
+  integrity sha512-lNS9hL2aS2NZgNW7BBj+6EBl4rOf8l+tQ0eRY6JWCI8jI2kc53gSoqbjojU0OnAWhzoXiOjFyGsHcDGePB3lhA==
+  dependencies:
+    quansync "^0.2.11"
+
+"@rolldown/binding-android-arm64@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-beta.38.tgz#8f56cb4e63acc36db914bd1f9e92ca8773757674"
+  integrity sha512-AE3HFQrjWCKLFZD1Vpiy+qsqTRwwoil1oM5WsKPSmfQ5fif/A+ZtOZetF32erZdsR7qyvns6qHEteEsF6g6rsQ==
+
+"@rolldown/binding-darwin-arm64@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-beta.38.tgz#ed086209da74f8dbe684e51cdbc167a9bd038ab0"
+  integrity sha512-RaoWOKc0rrFsVmKOjQpebMY6c6/I7GR1FBc25v7L/R7NlM0166mUotwGEv7vxu7ruXH4SJcFeVrfADFUUXUmmQ==
+
+"@rolldown/binding-darwin-x64@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-beta.38.tgz#f1bfd8f13efe1469ceaa73be4ad7444200f48f16"
+  integrity sha512-Ymojqc2U35iUc8NFU2XX1WQPfBRRHN6xHcrxAf9WS8BFFBn8pDrH5QPvH1tYs3lDkw6UGGbanr1RGzARqdUp1g==
+
+"@rolldown/binding-freebsd-x64@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-beta.38.tgz#00bc3d9c7ac4204792a328ea7a6b48e3bea340a7"
+  integrity sha512-0ermTQ//WzSI0nOL3z/LUWMNiE9xeM5cLGxjewPFEexqxV/0uM8/lNp9QageQ8jfc/VO1OURsGw34HYO5PaL8w==
+
+"@rolldown/binding-linux-arm-gnueabihf@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-beta.38.tgz#00b12fc837220f0bb4a28cad933365d9e9c10b23"
+  integrity sha512-GADxzVUTCTp6EWI52831A29Tt7PukFe94nhg/SUsfkI33oTiNQtPxyLIT/3oRegizGuPSZSlrdBurkjDwxyEUQ==
+
+"@rolldown/binding-linux-arm64-gnu@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-beta.38.tgz#1d27fb03a23fc94280b499a11a6a81fb5dd943c5"
+  integrity sha512-SKO7Exl5Yem/OSNoA5uLHzyrptUQ8Hg70kHDxuwEaH0+GUg+SQe9/7PWmc4hFKBMrJGdQtii8WZ0uIz9Dofg5Q==
+
+"@rolldown/binding-linux-arm64-musl@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-beta.38.tgz#55aa5a5e1262ccc8bf7655a8199fac1384d6ff04"
+  integrity sha512-SOo6+WqhXPBaShLxLT0eCgH17d3Yu1lMAe4mFP0M9Bvr/kfMSOPQXuLxBcbBU9IFM9w3N6qP9xWOHO+oUJvi8Q==
+
+"@rolldown/binding-linux-x64-gnu@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-beta.38.tgz#72d67e0cecdcc9622c618a0bb1f36de5a51483a8"
+  integrity sha512-yvsQ3CyrodOX+lcoi+lejZGCOvJZa9xTsNB8OzpMDmHeZq3QzJfpYjXSAS6vie70fOkLVJb77UqYO193Cl8XBQ==
+
+"@rolldown/binding-linux-x64-musl@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-beta.38.tgz#b4eca72e514f85636a32fa8d1b2c44a88a3b72e1"
+  integrity sha512-84qzKMwUwikfYeOuJ4Kxm/3z15rt0nFGGQArHYIQQNSTiQdxGHxOkqXtzPFqrVfBJUdxBAf+jYzR1pttFJuWyg==
+
+"@rolldown/binding-openharmony-arm64@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-beta.38.tgz#e2a13492eb40f1f69e2b10dc320595235af12bbe"
+  integrity sha512-QrNiWlce01DYH0rL8K3yUBu+lNzY+B0DyCbIc2Atan6/S6flxOL0ow5DLQvMamOI/oKhrJ4xG+9MkMb9dDHbLQ==
+
+"@rolldown/binding-wasm32-wasi@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-beta.38.tgz#910163a0726813e7adc07a49d62dcf3739b600c6"
+  integrity sha512-fnLtHyjwEsG4/aNV3Uv3Qd1ZbdH+CopwJNoV0RgBqrcQB8V6/Qdikd5JKvnO23kb3QvIpP+dAMGZMv1c2PJMzw==
+  dependencies:
+    "@napi-rs/wasm-runtime" "^1.0.5"
+
+"@rolldown/binding-win32-arm64-msvc@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-beta.38.tgz#c6ea254ab0a0603ce79e3d41c7d89f339d946711"
+  integrity sha512-19cTfnGedem+RY+znA9J6ARBOCEFD4YSjnx0p5jiTm9tR6pHafRfFIfKlTXhun+NL0WWM/M0eb2IfPPYUa8+wg==
+
+"@rolldown/binding-win32-ia32-msvc@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.0.0-beta.38.tgz#d9ab9c2ec9d697c9161418c205c49b9e2831c024"
+  integrity sha512-HcICm4YzFJZV+fI0O0bFLVVlsWvRNo/AB9EfUXvNYbtAxakCnQZ15oq22deFdz6sfi9Y4/SagH2kPU723dhCFA==
+
+"@rolldown/binding-win32-x64-msvc@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-beta.38.tgz#9dcec746d6315e9a4362a40e2863b433d698c057"
+  integrity sha512-4Qx6cgEPXLb0XsCyLoQcUgYBpfL0sjugftob+zhUH0EOk/NVCAIT+h0NJhY+jn7pFpeKxhNMqhvTNx3AesxIAQ==
+
+"@rolldown/pluginutils@1.0.0-beta.38":
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.38.tgz#95253608c4629eb2a5f3d656009ac9ba031eb292"
+  integrity sha512-N/ICGKleNhA5nc9XXQG/kkKHJ7S55u0x0XUJbbkmdCnFuoRkM1Il12q9q0eX19+M7KKUEPw/daUPIRnxhcxAIw==
+
+"@rollup/rollup-android-arm-eabi@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.0.tgz#dfcddfa85a3cba8a0e95483b4a7255ab9e4cdf4d"
+  integrity sha512-VxDYCDqOaR7NXzAtvRx7G1u54d2kEHopb28YH/pKzY6y0qmogP3gG7CSiWsq9WvDFxOQMpNEyjVAHZFXfH3o/A==
+
+"@rollup/rollup-android-arm64@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.0.tgz#f37b4a8741a7f42d2f2921bd621e7e824a262f0c"
+  integrity sha512-pqDirm8koABIKvzL59YI9W9DWbRlTX7RWhN+auR8HXJxo89m4mjqbah7nJZjeKNTNYopqL+yGg+0mhCpf3xZtQ==
+
 "@rollup/rollup-darwin-arm64@4.52.0":
   version "4.52.0"
   resolved "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.0.tgz"
   integrity sha512-YCdWlY/8ltN6H78HnMsRHYlPiKvqKagBP1r+D7SSylxX+HnsgXGCmLiV3Y4nSyY9hW8qr8U9LDUx/Lo7M6MfmQ==
+
+"@rollup/rollup-darwin-x64@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.0.tgz#c6008839852a33a686080957d296f727af9ca80d"
+  integrity sha512-z4nw6y1j+OOSGzuVbSWdIp1IUks9qNw4dc7z7lWuWDKojY38VMWBlEN7F9jk5UXOkUcp97vA1N213DF+Lz8BRg==
+
+"@rollup/rollup-freebsd-arm64@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.0.tgz#2b3ee9028493fd58245ded2137de0bc5d6b8f1e4"
+  integrity sha512-Q/dv9Yvyr5rKlK8WQJZVrp5g2SOYeZUs9u/t2f9cQ2E0gJjYB/BWoedXfUT0EcDJefi2zzVfhcOj8drWCzTviw==
+
+"@rollup/rollup-freebsd-x64@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.0.tgz#32e1ed194ceb3e0ef204efa237c04db13dece948"
+  integrity sha512-kdBsLs4Uile/fbjZVvCRcKB4q64R+1mUq0Yd7oU1CMm1Av336ajIFqNFovByipciuUQjBCPMxwJhCgfG2re3rg==
+
+"@rollup/rollup-linux-arm-gnueabihf@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.0.tgz#e64b1b7b2744803d7f52701f8bbd2989ae399424"
+  integrity sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==
+
+"@rollup/rollup-linux-arm-musleabihf@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.0.tgz#cef6569f633cacd09ad89189b9a805067141e01f"
+  integrity sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==
+
+"@rollup/rollup-linux-arm64-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.0.tgz#358c20dc375f80e20048f99f46b507d6d8063fdf"
+  integrity sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==
+
+"@rollup/rollup-linux-arm64-musl@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.0.tgz#8141352ddffbf4200b464c1e1957c050f5c0842a"
+  integrity sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==
+
+"@rollup/rollup-linux-loong64-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.0.tgz#d92ac6909a29c9f3793e12fdd826d81a0eef0966"
+  integrity sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==
+
+"@rollup/rollup-linux-ppc64-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.0.tgz#01aacb8e24c41fc5bed2d592c34c210e92975cd3"
+  integrity sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==
+
+"@rollup/rollup-linux-riscv64-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.0.tgz#fe3224c04b005a378b22f53f3be718c6c175d782"
+  integrity sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==
+
+"@rollup/rollup-linux-riscv64-musl@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.0.tgz#ff25daa05f99c77f43e4d8eef02d57c231dac6ed"
+  integrity sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==
+
+"@rollup/rollup-linux-s390x-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.0.tgz#7afac92ea34b129e1430351f615b9f6a84f6510d"
+  integrity sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==
+
+"@rollup/rollup-linux-x64-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.0.tgz#214b534701614c7502603e2a083bb9f072ae8500"
+  integrity sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==
+
+"@rollup/rollup-linux-x64-musl@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.0.tgz#8bdc313319fb097795b9213782354afeb8452658"
+  integrity sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==
+
+"@rollup/rollup-openharmony-arm64@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.0.tgz#3a6050fc85143f14039c2e8f8f6e90e9e60a392c"
+  integrity sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==
+
+"@rollup/rollup-win32-arm64-msvc@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.0.tgz#7a57e55beeb598b7a27786e95142f39fff5daddb"
+  integrity sha512-YQugafP/rH0eOOHGjmNgDURrpYHrIX0yuojOI8bwCyXwxC9ZdTd3vYkmddPX0oHONLXu9Rb1dDmT0VNpjkzGGw==
+
+"@rollup/rollup-win32-ia32-msvc@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.0.tgz#a7a7a1b5d53bd3fdddf494106961c018a39f6f77"
+  integrity sha512-zYdUYhi3Qe2fndujBqL5FjAFzvNeLxtIqfzNEVKD1I7C37/chv1VxhscWSQHTNfjPCrBFQMnynwA3kpZpZ8w4A==
+
+"@rollup/rollup-win32-x64-gnu@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.0.tgz#45040d6623b0db5dd3b9ee0054708ba8b25cd787"
+  integrity sha512-fGk03kQylNaCOQ96HDMeT7E2n91EqvCDd3RwvT5k+xNdFCeMGnj5b5hEgTGrQuyidqSsD3zJDQ21QIaxXqTBJw==
+
+"@rollup/rollup-win32-x64-msvc@4.52.0":
+  version "4.52.0"
+  resolved "https://registry.yarnpkg.com/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.0.tgz#79bc6c361bd80134402274e7c4a6bb36c88d50c2"
+  integrity sha512-6iKDCVSIUQ8jPMoIV0OytRKniaYyy5EbY/RRydmLW8ZR3cEBhxbWl5ro0rkUNe0ef6sScvhbY79HrjRm8i3vDQ==
+
+"@tybys/wasm-util@^0.10.1":
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/@tybys/wasm-util/-/wasm-util-0.10.1.tgz#ecddd3205cf1e2d5274649ff0eedd2991ed7f414"
+  integrity sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==
+  dependencies:
+    tslib "^2.4.0"
 
 "@types/estree@1.0.8":
   version "1.0.8"
@@ -210,7 +603,7 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.15.0, acorn@^8.9.0:
+acorn@^8.15.0, acorn@^8.9.0:
   version "8.15.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz"
   integrity sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==
@@ -247,6 +640,11 @@ ansi-styles@^6.1.0:
   resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz"
   integrity sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==
 
+ansis@^4.0.0, ansis@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.1.0.tgz#cd43ecd3f814f37223e518291c0e0b04f2915a0d"
+  integrity sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==
+
 any-promise@^1.0.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz"
@@ -262,10 +660,23 @@ array-union@^2.1.0:
   resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
+ast-kit@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/ast-kit/-/ast-kit-2.1.2.tgz#167da747afd8bdf3762c702bdc436376100332be"
+  integrity sha512-cl76xfBQM6pztbrFWRnxbrDm9EOqDr1BF6+qQnnDZG2Co2LjyUktkN9GTJfBAfdae+DbT2nJf2nCGAdDDN7W2g==
+  dependencies:
+    "@babel/parser" "^7.28.0"
+    pathe "^2.0.3"
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
+
+birpc@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/birpc/-/birpc-2.5.0.tgz#3a014e54c17eceba0ce15738d484ea371dbf6527"
+  integrity sha512-VSWO/W6nNQdyP520F1mhf+Lc2f8pjGQOtoHHm7Ze8Go1kX7akpVIrtTa0fn+HB0QJEDVacl6aO08YE0PgXfdnQ==
 
 brace-expansion@^1.1.7:
   version "1.1.12"
@@ -369,10 +780,27 @@ debug@^4.3.1, debug@^4.3.2, debug@^4.3.4, debug@^4.4.0:
   dependencies:
     ms "^2.1.3"
 
+debug@^4.4.3:
+  version "4.4.3"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
+  integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
+  dependencies:
+    ms "^2.1.3"
+
 deep-is@^0.1.3:
   version "0.1.4"
   resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+defu@^6.1.4:
+  version "6.1.4"
+  resolved "https://registry.yarnpkg.com/defu/-/defu-6.1.4.tgz#4e0c9cf9ff68fe5f3d7f2765cc1a012dfdcb0479"
+  integrity sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==
+
+diff@^8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-8.0.2.tgz#712156a6dd288e66ebb986864e190c2fc9eddfae"
+  integrity sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg==
 
 dir-glob@^3.0.1:
   version "3.0.1"
@@ -387,6 +815,11 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dts-resolver@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/dts-resolver/-/dts-resolver-2.1.2.tgz#58b05893403984cbc0a85f61f90057eaf365faf7"
+  integrity sha512-xeXHBQkn2ISSXxbJWD828PFjtyg+/UrMDo7W4Ffcs7+YWCquxU8YjV1KoxuiL+eJ5pg3ll+bC6flVv61L3LKZg==
 
 eastasianwidth@^0.2.0:
   version "0.2.0"
@@ -403,7 +836,12 @@ emoji-regex@^9.2.2:
   resolved "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz"
   integrity sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==
 
-esbuild@^0.25.0, esbuild@>=0.18:
+empathic@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/empathic/-/empathic-2.0.0.tgz#71d3c2b94fad49532ef98a6c34be0386659f6131"
+  integrity sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==
+
+esbuild@^0.25.0:
   version "0.25.10"
   resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz"
   integrity sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==
@@ -461,7 +899,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-"eslint@^6.0.0 || ^7.0.0 || ^8.0.0", "eslint@^6.0.0 || ^7.0.0 || >=8.0.0", eslint@^8.0.0:
+eslint@^8.0.0:
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -639,6 +1077,18 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+get-tsconfig@^4.10.1:
+  version "4.10.1"
+  resolved "https://registry.yarnpkg.com/get-tsconfig/-/get-tsconfig-4.10.1.tgz#d34c1c01f47d65a606c37aa7a177bc3e56ab4b2e"
+  integrity sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==
+  dependencies:
+    resolve-pkg-maps "^1.0.0"
+
 glob-parent@^5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
@@ -705,6 +1155,11 @@ has-flag@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
+hookable@^5.5.3:
+  version "5.5.3"
+  resolved "https://registry.yarnpkg.com/hookable/-/hookable-5.5.3.tgz#6cfc358984a1ef991e2518cb9ed4a778bbd3215d"
+  integrity sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -778,6 +1233,11 @@ jackspeak@^3.1.2:
   optionalDependencies:
     "@pkgjs/parseargs" "^0.11.0"
 
+jiti@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/jiti/-/jiti-2.5.1.tgz#bd099c1c2be1c59bbea4e5adcd127363446759d0"
+  integrity sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==
+
 joycon@^3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz"
@@ -789,6 +1249,11 @@ js-yaml@^4.1.0:
   integrity sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==
   dependencies:
     argparse "^2.0.1"
+
+jsesc@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-3.1.0.tgz#74d335a234f67ed19907fdadfac7ccf9d409825d"
+  integrity sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==
 
 json-buffer@3.0.1:
   version "3.0.1"
@@ -857,7 +1322,7 @@ lru-cache@^10.2.0:
   resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz"
   integrity sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==
 
-magic-string@^0.30.17:
+magic-string@^0.30.17, magic-string@^0.30.19:
   version "0.30.19"
   resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.19.tgz"
   integrity sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==
@@ -1018,7 +1483,7 @@ picomatch@^2.3.1:
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
-"picomatch@^3 || ^4", picomatch@^4.0.3:
+picomatch@^4.0.3:
   version "4.0.3"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz"
   integrity sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==
@@ -1059,6 +1524,11 @@ punycode@^2.1.0:
   resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
 
+quansync@^0.2.11:
+  version "0.2.11"
+  resolved "https://registry.yarnpkg.com/quansync/-/quansync-0.2.11.tgz#f9c3adda2e1272e4f8cf3f1457b04cbdb4ee692a"
+  integrity sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==
+
 queue-microtask@^1.2.2:
   version "1.2.3"
   resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
@@ -1079,6 +1549,11 @@ resolve-from@^5.0.0:
   resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
+resolve-pkg-maps@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz#616b3dc2c57056b5588c31cdf4b3d64db133720f"
+  integrity sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==
+
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
@@ -1090,6 +1565,45 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
+
+rolldown-plugin-dts@^0.16.5:
+  version "0.16.6"
+  resolved "https://registry.yarnpkg.com/rolldown-plugin-dts/-/rolldown-plugin-dts-0.16.6.tgz#e9c920c89afb65352307b7713213b2b79fd26637"
+  integrity sha512-OPQKAft45efpjU3ppcI9GyRHAT0otTIdMv0gcoBlcR9B3QssZvTFH6zbT3Ij5x+7ymX5TCPyHb+VIkRYTJrTaA==
+  dependencies:
+    "@babel/generator" "^7.28.3"
+    "@babel/parser" "^7.28.4"
+    "@babel/types" "^7.28.4"
+    ast-kit "^2.1.2"
+    birpc "^2.5.0"
+    debug "^4.4.3"
+    dts-resolver "^2.1.2"
+    get-tsconfig "^4.10.1"
+    magic-string "^0.30.19"
+
+rolldown@latest:
+  version "1.0.0-beta.38"
+  resolved "https://registry.yarnpkg.com/rolldown/-/rolldown-1.0.0-beta.38.tgz#5a33fb06ed6fd69e71ef38dab97cc6a1f891babd"
+  integrity sha512-58frPNX55Je1YsyrtPJv9rOSR3G5efUZpRqok94Efsj0EUa8dnqJV3BldShyI7A+bVPleucOtzXHwVpJRcR0kQ==
+  dependencies:
+    "@oxc-project/types" "=0.89.0"
+    "@rolldown/pluginutils" "1.0.0-beta.38"
+    ansis "^4.0.0"
+  optionalDependencies:
+    "@rolldown/binding-android-arm64" "1.0.0-beta.38"
+    "@rolldown/binding-darwin-arm64" "1.0.0-beta.38"
+    "@rolldown/binding-darwin-x64" "1.0.0-beta.38"
+    "@rolldown/binding-freebsd-x64" "1.0.0-beta.38"
+    "@rolldown/binding-linux-arm-gnueabihf" "1.0.0-beta.38"
+    "@rolldown/binding-linux-arm64-gnu" "1.0.0-beta.38"
+    "@rolldown/binding-linux-arm64-musl" "1.0.0-beta.38"
+    "@rolldown/binding-linux-x64-gnu" "1.0.0-beta.38"
+    "@rolldown/binding-linux-x64-musl" "1.0.0-beta.38"
+    "@rolldown/binding-openharmony-arm64" "1.0.0-beta.38"
+    "@rolldown/binding-wasm32-wasi" "1.0.0-beta.38"
+    "@rolldown/binding-win32-arm64-msvc" "1.0.0-beta.38"
+    "@rolldown/binding-win32-ia32-msvc" "1.0.0-beta.38"
+    "@rolldown/binding-win32-x64-msvc" "1.0.0-beta.38"
 
 rollup@^4.34.8:
   version "4.52.0"
@@ -1129,7 +1643,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-semver@^7.3.7:
+semver@^7.3.7, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
@@ -1260,7 +1774,12 @@ tinyexec@^0.3.2:
   resolved "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz"
   integrity sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==
 
-tinyglobby@^0.2.11:
+tinyexec@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tinyexec/-/tinyexec-1.0.1.tgz#70c31ab7abbb4aea0a24f55d120e5990bfa1e0b1"
+  integrity sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==
+
+tinyglobby@^0.2.11, tinyglobby@^0.2.15:
   version "0.2.15"
   resolved "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz"
   integrity sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==
@@ -1292,10 +1811,35 @@ ts-interface-checker@^0.1.9:
   resolved "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz"
   integrity sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==
 
+tsdown@^0.15.3:
+  version "0.15.3"
+  resolved "https://registry.yarnpkg.com/tsdown/-/tsdown-0.15.3.tgz#4a099fb0b9c87da9beb02b38efc29dc2ecf5d9c8"
+  integrity sha512-51p2z1F3GBAG9+9J+BNo6rYCvajZ9TAGtFMq/hCwjhvxFbzJ/Py4SHmLNltbraR4QFepW694cZwab33Nb7H2Ew==
+  dependencies:
+    ansis "^4.1.0"
+    cac "^6.7.14"
+    chokidar "^4.0.3"
+    debug "^4.4.3"
+    diff "^8.0.2"
+    empathic "^2.0.0"
+    hookable "^5.5.3"
+    rolldown latest
+    rolldown-plugin-dts "^0.16.5"
+    semver "^7.7.2"
+    tinyexec "^1.0.1"
+    tinyglobby "^0.2.15"
+    tree-kill "^1.2.2"
+    unconfig "^7.3.3"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.4.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsup@^8.5.0:
   version "8.5.0"
@@ -1339,7 +1883,7 @@ type-fest@^0.20.2:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-"typescript@>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta", typescript@>=4.5.0, typescript@~5.0.4:
+typescript@~5.0.4:
   version "5.0.4"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.0.4.tgz"
   integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
@@ -1348,6 +1892,16 @@ ufo@^1.6.1:
   version "1.6.1"
   resolved "https://registry.npmjs.org/ufo/-/ufo-1.6.1.tgz"
   integrity sha512-9a4/uxlTWJ4+a5i0ooc1rU7C7YOw3wT+UGqdeNNHWnOF9qcMBgLRS+4IYUqbczewFx4mLEig6gawh7X6mFlEkA==
+
+unconfig@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/unconfig/-/unconfig-7.3.3.tgz#bdb2dbbb5d271e601bc7e0922512ce397c5a9e8d"
+  integrity sha512-QCkQoOnJF8L107gxfHL0uavn7WD9b3dpBcFX6HtfQYmjw2YzWxGuFQ0N0J6tE9oguCBJn9KOvfqYDCMPHIZrBA==
+  dependencies:
+    "@quansync/fs" "^0.1.5"
+    defu "^6.1.4"
+    jiti "^2.5.1"
+    quansync "^0.2.11"
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
- Replace tsup with tsdown for improved bundling performance
- Update package.json build script to use tsdown
- Rename tsup.config.ts to tsdown.config.ts
- Enhanced bundling with rolldown runtime
- Improved module handling and tree-shaking