### PR TITLE
Fix: Merge custom ignoreLiterals with defaults instead of replacing them

### DIFF
--- a/docs/rules/no-hardcoded-jsx-attributes.md
+++ b/docs/rules/no-hardcoded-jsx-attributes.md
@@ -69,10 +69,10 @@ User-facing attribute text (e.g., `aria-label`, `title`, `alt`) must be localiza
 
 ### Options
 
-- `ignoreLiterals` (string[], default: `["404", "N/A"]`) - Array of string literals to ignore. These strings will not trigger the rule when found in JSX attributes.
+- `ignoreLiterals` (string[], default: `["404", "N/A"]`) - Array of string literals to ignore. These strings will not trigger the rule when found in JSX attributes. **Custom values are merged with defaults**, so `"404"` and `"N/A"` are always ignored even when you provide custom values.
 - `caseSensitive` (boolean, default: `false`) - Whether to use case-sensitive matching when comparing against `ignoreLiterals`.
 - `trim` (boolean, default: `true`) - Whether to trim whitespace from strings before comparing against `ignoreLiterals`.
-- `ignoreComponentsWithTitle` (string[], default: `["Layout", "SEO"]`) - Array of component names where hardcoded `title` props are allowed. Only applies to the `title` attribute specifically.
+- `ignoreComponentsWithTitle` (string[], default: `["Layout", "SEO"]`) - Array of component names where hardcoded `title` props are allowed. Only applies to the `title` attribute specifically. **Custom values are merged with defaults**, so `"Layout"` and `"SEO"` are always allowed even when you provide custom components.
 
 **Note:** Numeric-only strings (e.g., `"1"`, `"123"`, `"999"`) are automatically ignored regardless of configuration options.
 
@@ -89,8 +89,10 @@ const UserProfile = () => <img alt="N/A" />; // ignored by default
 
 ```tsx
 // With configuration: { "ignoreLiterals": ["SKU-123", "v1.0"] }
-const Product = () => <div title="SKU-123" />; // ignored
-const Version = () => <span aria-label="v1.0" />; // ignored
+const Product = () => <div title="SKU-123" />; // ignored (custom)
+const Version = () => <span aria-label="v1.0" />; // ignored (custom)
+const ErrorPage = () => <div aria-label="404" />; // ignored (default, still preserved)
+const UserProfile = () => <img alt="N/A" />; // ignored (default, still preserved)
 ```
 
 ### Examples with component title exceptions
@@ -120,7 +122,8 @@ const Meta = () => <SEO alt="Logo" />; // ❌ triggers rule
 
 ```tsx
 // With configuration: { "ignoreComponentsWithTitle": ["PageWrapper", "Container"] }
-const CustomPage = () => <PageWrapper title="Custom Page" />; // ✅ allowed
-const Section = () => <Container title="Section Title" />; // ✅ allowed
-const Other = () => <Layout title="Page" />; // ❌ triggers rule (Layout not in custom list)
+const CustomPage = () => <PageWrapper title="Custom Page" />; // ✅ allowed (custom)
+const Section = () => <Container title="Section Title" />; // ✅ allowed (custom)
+const HomePage = () => <Layout title="Welcome" />; // ✅ allowed (default, still preserved)
+const BlogPost = () => <SEO title="Post Title" />; // ✅ allowed (default, still preserved)
 ```

--- a/docs/rules/no-hardcoded-jsx-text.md
+++ b/docs/rules/no-hardcoded-jsx-text.md
@@ -74,7 +74,7 @@ const C = () => (
 
 ### Options
 
-- `ignoreLiterals` (string[], default: `["404", "N/A"]`) - Array of string literals to ignore. These strings will not trigger the rule when found in JSX text.
+- `ignoreLiterals` (string[], default: `["404", "N/A"]`) - Array of string literals to ignore. These strings will not trigger the rule when found in JSX text. **Custom values are merged with defaults**, so `"404"` and `"N/A"` are always ignored even when you provide custom values.
 - `caseSensitive` (boolean, default: `false`) - Whether to use case-sensitive matching when comparing against `ignoreLiterals`.
 - `trim` (boolean, default: `true`) - Whether to trim whitespace from strings before comparing against `ignoreLiterals`.
 
@@ -93,6 +93,8 @@ const UserProfile = () => <span>N/A</span>; // ignored by default
 
 ```tsx
 // With configuration: { "ignoreLiterals": ["SKU-123", "v1.0"] }
-const Product = () => <div>SKU-123</div>; // ignored
-const Version = () => <span>v1.0</span>; // ignored
+const Product = () => <div>SKU-123</div>; // ignored (custom)
+const Version = () => <span>v1.0</span>; // ignored (custom)
+const ErrorPage = () => <div>404</div>; // ignored (default, still preserved)
+const UserProfile = () => <span>N/A</span>; // ignored (default, still preserved)
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,10 @@ var no_hardcoded_jsx_text_default = createRule$1({
 		trim: true
 	}],
 	create(context) {
-		const { ignoreLiterals = ["404", "N/A"], caseSensitive = false, trim: shouldTrim = true } = context.options[0] || {};
+		const options = context.options[0] || {};
+		const defaultIgnoreLiterals = ["404", "N/A"];
+		const { ignoreLiterals: customIgnoreLiterals = [], caseSensitive = false, trim: shouldTrim = true } = options;
+		const ignoreLiterals = [...defaultIgnoreLiterals, ...customIgnoreLiterals];
 		const shouldIgnoreString = (text) => {
 			let normalizedText = text;
 			if (shouldTrim) normalizedText = normalizedText.trim();
@@ -207,7 +210,12 @@ var no_hardcoded_jsx_attributes_default = createRule({
 		ignoreComponentsWithTitle: ["Layout", "SEO"]
 	}],
 	create(context) {
-		const { ignoreLiterals = ["404", "N/A"], caseSensitive = false, trim: shouldTrim = true, ignoreComponentsWithTitle = ["Layout", "SEO"] } = context.options[0] || {};
+		const options = context.options[0] || {};
+		const defaultIgnoreLiterals = ["404", "N/A"];
+		const defaultIgnoreComponentsWithTitle = ["Layout", "SEO"];
+		const { ignoreLiterals: customIgnoreLiterals = [], caseSensitive = false, trim: shouldTrim = true, ignoreComponentsWithTitle: customIgnoreComponentsWithTitle = [] } = options;
+		const ignoreLiterals = [...defaultIgnoreLiterals, ...customIgnoreLiterals];
+		const ignoreComponentsWithTitle = [...defaultIgnoreComponentsWithTitle, ...customIgnoreComponentsWithTitle];
 		const shouldIgnoreString = (text) => {
 			let normalizedText = text;
 			if (shouldTrim) normalizedText = normalizedText.trim();

--- a/src/no-hardcoded-jsx-attributes.ts
+++ b/src/no-hardcoded-jsx-attributes.ts
@@ -75,12 +75,21 @@ export default createRule<Options, MessageIds>({
   ],
   create(context) {
     const options = context.options[0] || {};
+    const defaultIgnoreLiterals = ["404", "N/A"];
+    const defaultIgnoreComponentsWithTitle = ["Layout", "SEO"];
     const {
-      ignoreLiterals = ["404", "N/A"],
+      ignoreLiterals: customIgnoreLiterals = [],
       caseSensitive = false,
       trim: shouldTrim = true,
-      ignoreComponentsWithTitle = ["Layout", "SEO"],
+      ignoreComponentsWithTitle: customIgnoreComponentsWithTitle = [],
     } = options;
+
+    // Merge default and custom ignore literals and components
+    const ignoreLiterals = [...defaultIgnoreLiterals, ...customIgnoreLiterals];
+    const ignoreComponentsWithTitle = [
+      ...defaultIgnoreComponentsWithTitle,
+      ...customIgnoreComponentsWithTitle,
+    ];
 
     const shouldIgnoreString = (text: string): boolean => {
       let normalizedText = text;

--- a/src/no-hardcoded-jsx-text.ts
+++ b/src/no-hardcoded-jsx-text.ts
@@ -58,11 +58,15 @@ export default createRule<Options, MessageIds>({
   ],
   create(context) {
     const options = context.options[0] || {};
+    const defaultIgnoreLiterals = ["404", "N/A"];
     const {
-      ignoreLiterals = ["404", "N/A"],
+      ignoreLiterals: customIgnoreLiterals = [],
       caseSensitive = false,
       trim: shouldTrim = true,
     } = options;
+
+    // Merge default and custom ignore literals
+    const ignoreLiterals = [...defaultIgnoreLiterals, ...customIgnoreLiterals];
 
     const shouldIgnoreString = (text: string): boolean => {
       let normalizedText = text;

--- a/tests/no-hardcoded-jsx-attributes.test.js
+++ b/tests/no-hardcoded-jsx-attributes.test.js
@@ -111,6 +111,15 @@ ruleTester.run("no-hardcoded-jsx-attributes with custom ignore list", rule, {
       code: 'const C = () => <img alt={"v1.0"} />;',
       options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
     },
+    // Default values should be preserved when custom ignoreLiterals are provided
+    {
+      code: 'const C = () => <div aria-label="N/A" />;',
+      options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
+    },
+    {
+      code: 'const C = () => <img alt="404" />;',
+      options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
+    },
   ],
   invalid: [
     {
@@ -184,6 +193,15 @@ ruleTester.run("no-hardcoded-jsx-attributes ignoreComponentsWithTitle", rule, {
     },
     {
       code: 'const C = () => <Container title={"Title"} />;',
+      options: [{ ignoreComponentsWithTitle: ["PageWrapper", "Container"] }],
+    },
+    // Default components (Layout, SEO) should be preserved when custom ignoreComponentsWithTitle are provided
+    {
+      code: 'const C = () => <Layout title="Page Title" />;',
+      options: [{ ignoreComponentsWithTitle: ["PageWrapper", "Container"] }],
+    },
+    {
+      code: 'const C = () => <SEO title="Page Title" />;',
       options: [{ ignoreComponentsWithTitle: ["PageWrapper", "Container"] }],
     },
   ],

--- a/tests/no-hardcoded-jsx-text.test.js
+++ b/tests/no-hardcoded-jsx-text.test.js
@@ -118,6 +118,11 @@ console.log("Running no-hardcoded-jsx-text ignoreLiterals tests...");
 ruleTester.run("no-hardcoded-jsx-text with custom ignore list", rule, {
   valid: [
     {
+      // default ignoreLiterals: [404,N/A]
+      code: "const C = () => <div>N/A</div>;",
+      options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
+    },
+    {
       code: "const C = () => <div>SKU-123</div>;",
       options: [{ ignoreLiterals: ["SKU-123", "v1.0"] }],
     },


### PR DESCRIPTION
## Summary

Fixes an issue where custom `ignoreLiterals` and `ignoreComponentsWithTitle` options would completely replace the default values instead of merging with them. This caused default ignore values like `"404"` and `"N/A"` to be lost when users provided custom configurations.

### Changes Made

- **Both rules now merge custom options with defaults:**
  - `ignoreLiterals`: Custom values are merged with defaults `["404", "N/A"]`
  - `ignoreComponentsWithTitle` (jsx-attributes only): Custom values are merged with defaults `["Layout", "SEO"]`

- **Added comprehensive test cases** to verify the merging behavior works correctly

- **Updated documentation** with clear explanations and examples showing that default values are preserved

### Before (❌ Broken)
```javascript
// Configuration: { "ignoreLiterals": ["SKU-123", "v1.0"] }
<div>N/A</div>      // ❌ Would trigger rule (N/A lost)
<div>404</div>      // ❌ Would trigger rule (404 lost)
<div>SKU-123</div>  // ✅ Ignored (custom)
```

### After (✅ Fixed)
```javascript
// Configuration: { "ignoreLiterals": ["SKU-123", "v1.0"] }
<div>N/A</div>      // ✅ Ignored (default preserved)
<div>404</div>      // ✅ Ignored (default preserved)  
<div>SKU-123</div>  // ✅ Ignored (custom)
<div>v1.0</div>     // ✅ Ignored (custom)
```

## Test plan

- [x] All existing tests pass
- [x] New test cases verify that default values are preserved when custom options are provided
- [x] Test both `ignoreLiterals` and `ignoreComponentsWithTitle` merging behavior
- [x] Documentation updated with clear examples
- [x] Bundle rebuilt and tested

## Files Changed

- `src/no-hardcoded-jsx-text.ts` - Fixed merging logic for `ignoreLiterals`
- `src/no-hardcoded-jsx-attributes.ts` - Fixed merging logic for both options
- `tests/` - Added test cases verifying merging behavior
- `docs/rules/` - Updated documentation with merging explanations
- `lib/index.js` - Updated compiled bundle